### PR TITLE
[filtering] STALTA cleanups

### DIFF
--- a/libs/seiscomp/math/filter/stalta.cpp
+++ b/libs/seiscomp/math/filter/stalta.cpp
@@ -17,7 +17,6 @@
  * gempa GmbH.                                                             *
  ***************************************************************************/
 
-#include<iostream>
 #include <seiscomp/core/exceptions.h>
 #include <seiscomp/math/filter/stalta.h>
 
@@ -156,7 +155,6 @@ STALTA2<TYPE>::setSamplingFrequency(double fsamp)
 	_numSTA = int(_lenSTA*_fsamp+0.5);
 	_numLTA = int(_lenLTA*_fsamp+0.5);
 	reset();
-std::cerr << "setSamplingFrequency fsamp=" << _fsamp << std::endl;
 }
 
 
@@ -193,7 +191,6 @@ STALTA2<TYPE>::apply(int ndata, TYPE *data)
 	double normLTA = 1./_numLTA;
 	double normSTA = 1./_numSTA;
 
-std::cerr << "apply fsamp=" << _fsamp << std::endl;
 	for (int i=0; i<ndata; i++, _sampleCount++) {
 
 		double current = FABS(data[i]);

--- a/libs/seiscomp/math/filter/stalta.cpp
+++ b/libs/seiscomp/math/filter/stalta.cpp
@@ -28,12 +28,12 @@ namespace Filtering {
 
 static void checkParameters(double lenSTA, double lenLTA)
 {
-	if (lenSTA > lenLTA)
-		throw Core::ValueException("STA length must not exceed LTA length");
 	if (lenSTA <= 0.)
 		throw Core::ValueException("STA length must be positive");
 	if (lenLTA <= 0.)
 		throw Core::ValueException("LTA length must be positive");
+	if (lenSTA > lenLTA)
+		throw Core::ValueException("STA length must not exceed LTA length");
 }
 
 

--- a/libs/seiscomp/math/filter/stalta.h
+++ b/libs/seiscomp/math/filter/stalta.h
@@ -105,9 +105,6 @@ class STALTA2 : public InPlaceFilter<TYPE> {
 		// length of STA and LTA windows in samples
 		int _numSTA, _numLTA;
 
-		// number of samples for init/reset
-		int _initSampleCount;
-
 		// number of samples processed since init/reset
 		int _sampleCount;
 
@@ -120,7 +117,11 @@ class STALTA2 : public InPlaceFilter<TYPE> {
 		// thresholds to declare an event on and off
 		double _eventOn, _eventOff;
 
-		double _bleed;
+		// This value controls how much the LTA will be updated during
+		// an event. Current values are only 0 and 1. With 0 meaning
+		// completely frozen LTA during the event, 1 meaning the LTA
+		// is fully updated.
+		double _updateLTA;
 };
 
 

--- a/libs/swig/math.i
+++ b/libs/swig/math.i
@@ -97,6 +97,8 @@ namespace std {
 %template(CityListF) std::vector<Seiscomp::Math::Geo::CityF>;
 %template(CityListD) std::vector<Seiscomp::Math::Geo::CityD>;
 
+%newobject Seiscomp::Math::Filtering::InPlaceFilter<float>::Create;
+%newobject Seiscomp::Math::Filtering::InPlaceFilter<double>::Create;
 %ignore Seiscomp::Math::Filtering::InPlaceFilter::apply(int, float*);
 %ignore Seiscomp::Math::Filtering::InPlaceFilter::apply(int, double*);
 %include "seiscomp/math/filter.h"
@@ -155,19 +157,17 @@ namespace std {
 %template(ButterworthBandstopF) Seiscomp::Math::Filtering::IIR::ButterworthBandstop<float>;
 %template(ButterworthBandstopD) Seiscomp::Math::Filtering::IIR::ButterworthBandstop<double>;
 
+
+%newobject Seiscomp::Math::Filtering::ChainFilter<float>::take;
+%newobject Seiscomp::Math::Filtering::ChainFilter<double>::take;
+
 %include "seiscomp/math/filter/chainfilter.h"
 
 %apply SWIGTYPE *DISOWN { Seiscomp::Math::Filtering::InPlaceFilter<float> *filter };
 %apply SWIGTYPE *DISOWN { Seiscomp::Math::Filtering::InPlaceFilter<double> *filter };
 
-%newobject Seiscomp::Math::Filtering::ChainFilter<float>::take;
-%newobject Seiscomp::Math::Filtering::ChainFilter<double>::take;
-
 %template(ChainFilterF) Seiscomp::Math::Filtering::ChainFilter<float>;
 %template(ChainFilterD) Seiscomp::Math::Filtering::ChainFilter<double>;
-
-%newobject Seiscomp::Math::Filtering::InplaceFilter<float>::Create;
-%newobject Seiscomp::Math::Filtering::InplaceFilter<double>::Create;
 
 %include "seiscomp/math/filter/seismometers.h"
 

--- a/libs/swig/math.i
+++ b/libs/swig/math.i
@@ -97,6 +97,8 @@ namespace std {
 %template(CityListF) std::vector<Seiscomp::Math::Geo::CityF>;
 %template(CityListD) std::vector<Seiscomp::Math::Geo::CityD>;
 
+%ignore Seiscomp::Math::Filtering::InPlaceFilter::apply(int, float*);
+%ignore Seiscomp::Math::Filtering::InPlaceFilter::apply(int, double*);
 %include "seiscomp/math/filter.h"
 
 %template(InPlaceFilterF) Seiscomp::Math::Filtering::InPlaceFilter<float>;
@@ -111,6 +113,12 @@ namespace std {
 
 %template(STALTAFilterF) Seiscomp::Math::Filtering::STALTA<float>;
 %template(STALTAFilterD) Seiscomp::Math::Filtering::STALTA<double>;
+%template(STALTA2FilterF) Seiscomp::Math::Filtering::STALTA2<float>;
+%template(STALTA2FilterD) Seiscomp::Math::Filtering::STALTA2<double>;
+%template(STALTAClassicFilterF) Seiscomp::Math::Filtering::STALTA_Classic<float>;
+%template(STALTAClassicFilterD) Seiscomp::Math::Filtering::STALTA_Classic<double>;
+
+
 
 %include "seiscomp/math/filter/rmhp.h"
 

--- a/libs/swig/math.i
+++ b/libs/swig/math.i
@@ -169,10 +169,21 @@ namespace std {
 %template(ChainFilterF) Seiscomp::Math::Filtering::ChainFilter<float>;
 %template(ChainFilterD) Seiscomp::Math::Filtering::ChainFilter<double>;
 
+%ignore Seiscomp::Math::Filtering::IIR::Filter<float>::apply(int, float*);
+%ignore Seiscomp::Math::Filtering::IIR::Filter<double>::apply(int, double*);
+
 %include "seiscomp/math/filter/seismometers.h"
 
+%template(SeismometerFilterF) Seiscomp::Math::Filtering::IIR::Filter<float>;
+%template(SeismometerFilterD) Seiscomp::Math::Filtering::IIR::Filter<double>;
 %template(WWSSN_SPF) Seiscomp::Math::Filtering::IIR::WWSSN_SP_Filter<float>;
 %template(WWSSN_SPD) Seiscomp::Math::Filtering::IIR::WWSSN_SP_Filter<double>;
+%template(WWSSN_LPF) Seiscomp::Math::Filtering::IIR::WWSSN_LP_Filter<float>;
+%template(WWSSN_LPD) Seiscomp::Math::Filtering::IIR::WWSSN_LP_Filter<double>;
+%template(WoodAndersonFilterF) Seiscomp::Math::Filtering::IIR::WoodAndersonFilter<float>;
+%template(WoodAndersonFilterD) Seiscomp::Math::Filtering::IIR::WoodAndersonFilter<double>;
+%template(GenericSeismometerFilterF) Seiscomp::Math::Filtering::IIR::GenericSeismometer<float>;
+%template(GenericSeismometerFilterD) Seiscomp::Math::Filtering::IIR::GenericSeismometer<double>;
 
 %include "seiscomp/math/geo.h"
 


### PR DESCRIPTION
This is a cleanup of the STALTA filters. Changes include:

* General cleanups and improved readability
* Improved behavior at the beginning of a segment, with the initialization time reduced to the length of the STA window. This has turned out to be enough and also robust.
* Addition of a non-recursive STALTA_Classic class.
* Updated math.i to generate the proper Python wrappers.