### PR TITLE
Adding tooltips for costum columns in scolv

### DIFF
--- a/libs/seiscomp/gui/datamodel/eventedit.cpp
+++ b/libs/seiscomp/gui/datamodel/eventedit.cpp
@@ -2035,6 +2035,7 @@ void EventEdit::updateOriginRow(int row, Origin *org) {
 			if ( c->id() != _commentID ) continue;
 
 			item->setText(_customColumn, c->text().c_str());
+			item->setToolTip(_customColumn, c->text().c_str());
 			QMap<std::string, QColor>::const_iterator it =
 				_customColorMap.find(c->text());
 			if ( it != _customColorMap.end() )

--- a/libs/seiscomp/gui/datamodel/eventlistview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventlistview.cpp
@@ -889,11 +889,13 @@ class OriginTreeItem : public SchemeTreeItem {
 
 			if ( config.customColumn != -1 ) {
 				setText(config.customColumn, config.customDefaultText);
+			  setToolTip(config.customColumn, config.customDefaultText);
 				setData(config.customColumn, Qt::ForegroundRole, QVariant());
 				if ( !config.originCommentID.empty() ) {
 					for ( size_t i = 0; i < ori->commentCount(); ++i ) {
 						if ( ori->comment(i)->id() == config.originCommentID ) {
 							setText(config.customColumn, ori->comment(i)->text().c_str());
+							setToolTip(config.customColumn, ori->comment(i)->text().c_str());
 							QMap<std::string, QColor>::const_iterator it =
 								config.customColorMap.find(ori->comment(i)->text());
 							if ( it != config.customColorMap.end() )
@@ -1525,10 +1527,12 @@ class EventTreeItem : public SchemeTreeItem {
 					if ( config.customColumn != -1 ) {
 						setData(config.customColumn, Qt::ForegroundRole, QVariant());
 						setText(config.customColumn, config.customDefaultText);
+						setToolTip(config.customColumn, config.customDefaultText); 
 						if ( !config.originCommentID.empty() ) {
 							for ( size_t i = 0; i < origin->commentCount(); ++i ) {
 								if ( origin->comment(i)->id() == config.originCommentID ) {
 									setText(config.customColumn, origin->comment(i)->text().c_str());
+									setToolTip(config.customColumn, origin->comment(i)->text().c_str()); 
 									QMap<std::string, QColor>::const_iterator it =
 										config.customColorMap.find(origin->comment(i)->text());
 									if ( it != config.customColorMap.end() )
@@ -1542,6 +1546,7 @@ class EventTreeItem : public SchemeTreeItem {
 								if ( ev->comment(i)->id() == config.eventCommentID ) {
 									if( ev->comment(i)->text().empty() ) break;
 									setText(config.customColumn, ev->comment(i)->text().c_str());
+									setToolTip(config.customColumn, ev->comment(i)->text().c_str());
 									QMap<std::string, QColor>::const_iterator it =
 										config.customColorMap.find(ev->comment(i)->text());
 									if ( it != config.customColorMap.end() )


### PR DESCRIPTION
Dear Developers,

I would like to propose this change for the custom column option of scolv. When the custom column is created I would set the tooltip for that column to be the same as the content of the cell.

What do you think about it?

Regards,
Luca