### PR TITLE
Fix gap interpolation

### DIFF
--- a/libs/seiscomp/processing/waveformprocessor.cpp
+++ b/libs/seiscomp/processing/waveformprocessor.cpp
@@ -312,6 +312,16 @@ bool WaveformProcessor::store(const Record *record) {
 	// NOTE: Do not use else here, because lastRecord can be set nullptr
 	//       when calling reset() in handleGap(...)
 	if ( !_stream.lastRecord ) {
+
+		const auto minGapThres = 2 * 1.0 / record->samplingFrequency();
+		if ( minGapThres > _gapThreshold ) {
+			SEISCOMP_WARNING("Gap threshold smaller than twice the sampling interval: "
+			                 "%fs < %fs. Resetting gap threshold.",
+			                 static_cast<double>(_gapThreshold), minGapThres);
+
+			_gapThreshold = minGapThres;
+		}
+
 		try {
 			initFilter(record->samplingFrequency());
 		}

--- a/libs/seiscomp/processing/waveformprocessor.cpp
+++ b/libs/seiscomp/processing/waveformprocessor.cpp
@@ -438,9 +438,8 @@ bool WaveformProcessor::handleGap(Filter *filter, const Core::TimeSpan& span,
 				double value = lastSample + di*delta;
 				fill(1, &value);
 			}
+			return true;
 		}
-
-		return true;
 	}
 
 	return false;


### PR DESCRIPTION
This PR fixes two minor issues regarding gap interpolation:

- Correctly return whether gap was handled
- Compare `_gapThreshold` with sampling interval; the minimum allowed gap threshold is twice the sampling interval