### PR TITLE
Save last sample before filling values

### DIFF
--- a/libs/seiscomp/processing/waveformprocessor.cpp
+++ b/libs/seiscomp/processing/waveformprocessor.cpp
@@ -343,6 +343,7 @@ bool WaveformProcessor::store(const Record *record) {
 			                            record->locationCode(), record->channelCode());
 		}
 	}
+	_stream.lastSample = (*arr)[arr->size()-1];
 
 	// Fill the values and do the actual filtering
 	fill(arr->size(), arr->typedData());
@@ -362,7 +363,6 @@ bool WaveformProcessor::store(const Record *record) {
 		process(record, *arr);
 
 	_stream.lastRecord = record;
-	_stream.lastSample = (*arr)[arr->size()-1];
 
 	return true;
 }


### PR DESCRIPTION
If I'm not completely mistaken, there is an issue when saving the last sample after filling (filtering) the data. Instead,
the raw sample before filling needs to be saved. This is required since gaps are handled before data is filled.