### PR TITLE
Allow TimeWindowBuffer to return its TimeWindow

### DIFF
--- a/libs/seiscomp/core/recordsequence.h
+++ b/libs/seiscomp/core/recordsequence.h
@@ -175,6 +175,8 @@ class SC_SYSTEM_CORE_API TimeWindowBuffer : public RecordSequence {
 		//! Return percentage of available data within TimeWindowBuffer's TimeWindow
 		double availability() const;
 
+		//! Return the TimeWindow used in constructing the TimeWindowBuffer
+		const TimeWindow& timeWindow() const;
 
 	// ----------------------------------------------------------------------
 	//  Members
@@ -252,6 +254,9 @@ inline size_t RecordSequence::recordCount() const {
 	return size();
 }
 
+inline const TimeWindow& TimeWindowBuffer::timeWindow() const {
+	return _timeWindow;
+}
 
 }
 

--- a/libs/seiscomp/core/recordsequence.h
+++ b/libs/seiscomp/core/recordsequence.h
@@ -175,8 +175,8 @@ class SC_SYSTEM_CORE_API TimeWindowBuffer : public RecordSequence {
 		//! Return percentage of available data within TimeWindowBuffer's TimeWindow
 		double availability() const;
 
-		//! Return the TimeWindow used in constructing the TimeWindowBuffer
-		const TimeWindow& timeWindow() const;
+		//! Return the buffered TimeWindow
+		const Core::TimeWindow &bufferedTimeWindow() const;
 
 	// ----------------------------------------------------------------------
 	//  Members
@@ -227,6 +227,11 @@ class SC_SYSTEM_CORE_API RingBuffer : public RecordSequence {
 		//! clear the buffer
 		void reset() { clear(); }
 
+		//! Return the maximum number of records the RingBuffer stores
+		unsigned int maxNumRecords() const;
+	
+		//! Return the TimeSpan the RingBuffer stores
+		const Core::TimeSpan &timeSpan() const;
 
 	// ----------------------------------------------------------------------
 	//  Members
@@ -254,10 +259,18 @@ inline size_t RecordSequence::recordCount() const {
 	return size();
 }
 
-inline const TimeWindow& TimeWindowBuffer::timeWindow() const {
+inline const Core::TimeWindow &bufferedTimeWindow() const {
 	return _timeWindow;
 }
 
+inline unsigned int RingBuffer::maxNumRecords() const {
+	return _nmax;
+}
+	
+inline const Core::TimeSpan &RingBuffer::timeSpan() const {
+	return _span;
+}
+	
 }
 
 #endif

--- a/libs/seiscomp/core/recordsequence.h
+++ b/libs/seiscomp/core/recordsequence.h
@@ -176,7 +176,7 @@ class SC_SYSTEM_CORE_API TimeWindowBuffer : public RecordSequence {
 		double availability() const;
 
 		//! Return the buffered TimeWindow
-		const Core::TimeWindow &bufferedTimeWindow() const;
+		const Core::TimeWindow &timeWindowToStore() const;
 
 	// ----------------------------------------------------------------------
 	//  Members
@@ -228,10 +228,10 @@ class SC_SYSTEM_CORE_API RingBuffer : public RecordSequence {
 		void reset() { clear(); }
 
 		//! Return the maximum number of records the RingBuffer stores
-		unsigned int numberOfRecords() const;
+		unsigned int numberOfRecordsToStore() const;
 	
 		//! Return the TimeSpan the RingBuffer stores
-		const Core::TimeSpan &timeSpan() const;
+		const Core::TimeSpan &timeSpanToStore() const;
 
 	// ----------------------------------------------------------------------
 	//  Members
@@ -259,15 +259,15 @@ inline size_t RecordSequence::recordCount() const {
 	return size();
 }
 
-inline const Core::TimeWindow &bufferedTimeWindow() const {
+inline const Core::TimeWindow &timeWindowToStore() const {
 	return _timeWindow;
 }
 
-inline unsigned int RingBuffer::numberOfRecords() const {
+inline unsigned int RingBuffer::numberOfRecordsToStore() const {
 	return _nmax;
 }
 	
-inline const Core::TimeSpan &RingBuffer::timeSpan() const {
+inline const Core::TimeSpan &RingBuffer::timeSpanToStore() const {
 	return _span;
 }
 	

--- a/libs/seiscomp/core/recordsequence.h
+++ b/libs/seiscomp/core/recordsequence.h
@@ -228,7 +228,7 @@ class SC_SYSTEM_CORE_API RingBuffer : public RecordSequence {
 		void reset() { clear(); }
 
 		//! Return the maximum number of records the RingBuffer stores
-		unsigned int maxNumRecords() const;
+		unsigned int numberOfRecords() const;
 	
 		//! Return the TimeSpan the RingBuffer stores
 		const Core::TimeSpan &timeSpan() const;
@@ -263,7 +263,7 @@ inline const Core::TimeWindow &bufferedTimeWindow() const {
 	return _timeWindow;
 }
 
-inline unsigned int RingBuffer::maxNumRecords() const {
+inline unsigned int RingBuffer::numberOfRecords() const {
 	return _nmax;
 }
 	


### PR DESCRIPTION
This PR adds a convenience method that returns the TimeWindow the TimeWindowBuffer is constructed with. Currently there is no way to know that TimeWindow. In my code I have to keep a separate data structure just to access that information. Thanks for your review.