### PR TITLE
Consistently reset filters

### DIFF
--- a/libs/seiscomp/math/filter/abs.h
+++ b/libs/seiscomp/math/filter/abs.h
@@ -36,12 +36,12 @@ class AbsFilter : public InPlaceFilter<T> {
 		AbsFilter();
 
 	public:
-		void setSamplingFrequency(double fsamp);
-		int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		void apply(int n, T *inout);
+		void apply(int n, T *inout) override;
 
-		InPlaceFilter<T>* clone() const;
+		InPlaceFilter<T>* clone() const override;
 };
 
 }

--- a/libs/seiscomp/math/filter/average.cpp
+++ b/libs/seiscomp/math/filter/average.cpp
@@ -98,13 +98,10 @@ void Average<TYPE>::setSamplingFrequency(double fsamp) {
 	_fsamp = fsamp;
 	_sampleCount = (int)(_fsamp * _timeSpan);
 	if ( _sampleCount < 1 ) _sampleCount = 1;
-	_lastSum = 0;
-	_index = 0;
-
 	_oocount = 1.0/_sampleCount;
-
 	_buffer.resize(_sampleCount);
-	_firstSample = true;
+
+  reset();
 }
 
 

--- a/libs/seiscomp/math/filter/average.h
+++ b/libs/seiscomp/math/filter/average.h
@@ -21,8 +21,8 @@
 #ifndef SEISCOMP_MATH_FILTER_RCA_H
 #define SEISCOMP_MATH_FILTER_RCA_H
 
-#include<vector>
-#include<seiscomp/math/filter.h>
+#include <vector>
+#include <seiscomp/math/filter.h>
 
 
 namespace Seiscomp {
@@ -38,12 +38,12 @@ class Average : public InPlaceFilter<TYPE> {
 	public:
 		void setLength(double timeSpan);
 
-		virtual void setSamplingFrequency(double fsamp);
-		virtual int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
 		// apply filter to data vector **in*place**
-		virtual void apply(int n, TYPE *inout);
-		virtual InPlaceFilter<TYPE>* clone() const;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE>* clone() const override;
 
 		// Resets the filter values
 		void reset();

--- a/libs/seiscomp/math/filter/biquad.h
+++ b/libs/seiscomp/math/filter/biquad.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <ostream>
 
-#include<seiscomp/math/filter.h>
+#include <seiscomp/math/filter.h>
 
 
 namespace Seiscomp {
@@ -95,13 +95,13 @@ class Biquad : public InPlaceFilter<TYPE> {
 	// ------------------------------------------------------------------
 	public:
 		// apply filter to data vector **in*place**
-		virtual void apply(int n, TYPE *inout) override;
+		void apply(int n, TYPE *inout) override;
 
 		// Implement InPlaceFilter interface with default values
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE> *clone() const override;
+		InPlaceFilter<TYPE> *clone() const override;
 
 
 	// ------------------------------------------------------------------
@@ -147,11 +147,11 @@ class BiquadCascade : public InPlaceFilter<TYPE> {
 	// ------------------------------------------------------------------
 	public:
 		// apply filter to data vector **in*place**
-		virtual void apply(int n, TYPE *inout) override;
-		virtual InPlaceFilter<TYPE> *clone() const override;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE> *clone() const override;
 
-		virtual void setSamplingFrequency(double /*fsamp*/) override {}
-		virtual int setParameters(int n, const double *params) override ;
+		void setSamplingFrequency(double /*fsamp*/) override {}
+		int setParameters(int n, const double *params) override;
 
 
 	// ------------------------------------------------------------------

--- a/libs/seiscomp/math/filter/butterworth.h
+++ b/libs/seiscomp/math/filter/butterworth.h
@@ -22,7 +22,7 @@
 #define SEISCOMP_FILTERING_IIR_BUTTERWORTH_H
 
 
-#include<seiscomp/math/filter/biquad.h>
+#include <seiscomp/math/filter/biquad.h>
 
 
 namespace Seiscomp {
@@ -37,10 +37,10 @@ class ButterworthLowpass : public BiquadCascade<TYPE> {
 		ButterworthLowpass(int order = 3, double fmax = 0.7, double fsamp=0);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const override;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	private:
 		int _order;
@@ -54,10 +54,10 @@ class ButterworthHighpass : public BiquadCascade<TYPE> {
 		ButterworthHighpass(int order = 3, double fmin = 2.0, double fsamp=0);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const override;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	private:
 		int _order;
@@ -72,10 +72,10 @@ class ButterworthBandpass : public BiquadCascade<TYPE> {
 		                    double fsamp=0);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const;
+		InPlaceFilter<TYPE>* clone() const override;
 
 
 	protected:
@@ -92,10 +92,10 @@ class ButterworthBandstop : public BiquadCascade<TYPE> {
 		                    double fsamp=0);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	protected:
 		// configuration
@@ -111,10 +111,10 @@ class ButterworthHighLowpass : public BiquadCascade<TYPE> {
 		                       double fmax = 2.0, double fsamp = 0);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	private:
 		int _order;

--- a/libs/seiscomp/math/filter/chainfilter.h
+++ b/libs/seiscomp/math/filter/chainfilter.h
@@ -69,19 +69,19 @@ class ChainFilter : public InPlaceFilter<TYPE>
 	//  Derived filter interface
 	// ------------------------------------------------------------------
 	public:
-		virtual void apply(int n, TYPE *inout);
+		void apply(int n, TYPE *inout) override;
 
-		virtual void setStartTime(const Core::Time &time);
+		void setStartTime(const Core::Time &time) override;
 
-		virtual void setStreamID(const std::string &net,
+		void setStreamID(const std::string &net,
 		                         const std::string &sta,
 		                         const std::string &loc,
-		                         const std::string &cha);
+		                         const std::string &cha) override;
 
-		virtual void setSamplingFrequency(double fsamp);
-		virtual int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const;
+		InPlaceFilter<TYPE>* clone() const override;
 
 
 	// ------------------------------------------------------------------

--- a/libs/seiscomp/math/filter/const.h
+++ b/libs/seiscomp/math/filter/const.h
@@ -36,12 +36,12 @@ class ConstFilter : public InPlaceFilter<T> {
 		ConstFilter(T c = 1);
 
 	public:
-		void setSamplingFrequency(double fsamp);
-		int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		void apply(int n, T *inout);
+		void apply(int n, T *inout) override;
 
-		InPlaceFilter<T>* clone() const;
+		InPlaceFilter<T>* clone() const override;
 
 	private:
 		T _const;

--- a/libs/seiscomp/math/filter/cutoff.cpp
+++ b/libs/seiscomp/math/filter/cutoff.cpp
@@ -24,7 +24,7 @@
 
 #include <seiscomp/math/filter/cutoff.h>
 #include <seiscomp/core/exceptions.h>
-#include<seiscomp/logging/log.h>
+#include <seiscomp/logging/log.h>
 
 
 namespace Seiscomp {

--- a/libs/seiscomp/math/filter/cutoff.h
+++ b/libs/seiscomp/math/filter/cutoff.h
@@ -21,8 +21,8 @@
 #ifndef SEISCOMP_MATH_FILTER_CUTOFF_H
 #define SEISCOMP_MATH_FILTER_CUTOFF_H
 
-#include<vector>
-#include<seiscomp/math/filter.h>
+#include <vector>
+#include <seiscomp/math/filter.h>
 
 
 namespace Seiscomp
@@ -38,12 +38,12 @@ class CutOff : public InPlaceFilter<TYPE> {
 		CutOff(TYPE threshold = 0);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp);
-		virtual int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
 		// apply filter to data vector **in*place**
-		virtual void apply(int n, TYPE *inout);
-		virtual InPlaceFilter<TYPE>* clone() const;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	private:
 		TYPE _threshold;

--- a/libs/seiscomp/math/filter/iirdifferentiate.cpp
+++ b/libs/seiscomp/math/filter/iirdifferentiate.cpp
@@ -30,15 +30,14 @@ namespace Filtering
 
 template <typename T>
 IIRDifferentiate<T>::IIRDifferentiate(double fsamp) : _fsamp(fsamp) {
-	reset();
 	setSamplingFrequency(fsamp);
 }
 
 
 template <typename T>
 IIRDifferentiate<T>::IIRDifferentiate(const IIRDifferentiate<T> &other) {
-	_fsamp = 0.0;
-	reset();
+  _fsamp = 0.0;
+  reset();
 }
 
 
@@ -51,7 +50,10 @@ void IIRDifferentiate<T>::reset() {
 
 template <typename T>
 void IIRDifferentiate<T>::setSamplingFrequency(double fsamp) {
+	if ( fsamp == _fsamp) return;
+
 	_fsamp = fsamp;
+  reset();
 }
 
 

--- a/libs/seiscomp/math/filter/iirdifferentiate.h
+++ b/libs/seiscomp/math/filter/iirdifferentiate.h
@@ -21,7 +21,7 @@
 #ifndef SEISCOMP_IIRDIFFERENTIATE_H
 #define SEISCOMP_IIRDIFFERENTIATE_H
 
-#include<vector>
+#include <vector>
 #include <seiscomp/math/filter.h>
 
 
@@ -46,12 +46,12 @@ class IIRDifferentiate : public InPlaceFilter<T> {
 
 	// InPlaceFilter interface
 	public:
-		void setSamplingFrequency(double fsamp);
-		int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		void apply(int n, T *inout);
+		void apply(int n, T *inout) override;
 
-		InPlaceFilter<T>* clone() const;
+		InPlaceFilter<T>* clone() const override;
 
 	private:
 		T _v1;

--- a/libs/seiscomp/math/filter/iirintegrate.cpp
+++ b/libs/seiscomp/math/filter/iirintegrate.cpp
@@ -29,7 +29,8 @@ namespace Filtering
 
 
 template <typename T>
-IIRIntegrate<T>::IIRIntegrate(double a, double fsamp) {
+IIRIntegrate<T>::IIRIntegrate(double a, double fsamp)
+{
 	init(a);
 	setSamplingFrequency(fsamp);
 }
@@ -55,7 +56,7 @@ void IIRIntegrate<T>::init(double a) {
 	_b1 = 0;
 	_b2 = -1;
 
-	_v1 = _v2 = 0;
+	reset();
 }
 
 
@@ -70,10 +71,16 @@ void IIRIntegrate<T>::setSamplingFrequency(double fsamp) {
 	if ( !fsamp ) return;
 
 	double dt = 1./fsamp;
+	// NOTE: Check for changing sampling rate. Do not store `fsamp` in a member
+	// variable in order to keep binary compatibility.
+	double a0 = _ia0 * dt;
+	if ( _a0 != a0 ) {
+		_a0 = a0;
+		_a1 = _ia1 * dt;
+		_a2 = _ia2 * dt;
 
-	_a0 = _ia0 * dt;
-	_a1 = _ia1 * dt;
-	_a2 = _ia2 * dt;
+		reset();
+	}
 }
 
 

--- a/libs/seiscomp/math/filter/iirintegrate.h
+++ b/libs/seiscomp/math/filter/iirintegrate.h
@@ -21,7 +21,7 @@
 #ifndef SEISCOMP_IIRINTEGRATE_H
 #define SEISCOMP_IIRINTEGRATE_H
 
-#include<vector>
+#include <vector>
 #include <seiscomp/math/filter.h>
 
 
@@ -46,12 +46,12 @@ class IIRIntegrate : public InPlaceFilter<T> {
 
 	// InPlaceFilter interface
 	public:
-		void setSamplingFrequency(double fsamp);
-		int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		void apply(int n, T *inout);
+		void apply(int n, T *inout) override;
 
-		InPlaceFilter<T>* clone() const;
+		InPlaceFilter<T>* clone() const override;
 
 	private:
 		void init(double a);
@@ -60,9 +60,8 @@ class IIRIntegrate : public InPlaceFilter<T> {
 		double _ia0, _ia1, _ia2;
 
 		double _a0, _a1, _a2;
-        double _b0, _b1, _b2;
-
-        T _v1, _v2;
+		double _b0, _b1, _b2;
+		T _v1, _v2;
 };
 
 

--- a/libs/seiscomp/math/filter/minmax.cpp
+++ b/libs/seiscomp/math/filter/minmax.cpp
@@ -24,7 +24,7 @@
 
 #include <seiscomp/math/filter/minmax.h>
 #include <seiscomp/core/exceptions.h>
-#include<seiscomp/logging/log.h>
+#include <seiscomp/logging/log.h>
 
 
 namespace Seiscomp {
@@ -65,11 +65,8 @@ void MinMax<TYPE>::setSamplingFrequency(double fsamp) {
 	_fsamp = fsamp;
 	_sampleCount = (int)(_fsamp * _timeSpan);
 	if ( _sampleCount < 1 ) _sampleCount = 1;
-
-	_index = 0;
-
 	_buffer.resize(_sampleCount);
-	_firstSample = true;
+	reset();
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/libs/seiscomp/math/filter/minmax.h
+++ b/libs/seiscomp/math/filter/minmax.h
@@ -22,8 +22,8 @@
 #define SEISCOMP_MATH_FILTER_MINMAX_H
 
 
-#include<vector>
-#include<seiscomp/math/filter.h>
+#include <vector>
+#include <seiscomp/math/filter.h>
 
 
 namespace Seiscomp {
@@ -49,8 +49,8 @@ class MinMax : public InPlaceFilter<TYPE> {
 		 */
 		void setLength(double timeSpan);
 
-		virtual void setSamplingFrequency(double fsamp);
-		virtual int setParameters(int n, const double *params);
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
 		// Resets the filter values
 		void reset();
@@ -73,8 +73,8 @@ class Min : public MinMax<TYPE> {
 
 	public:
 		// apply filter to data vector **in*place**
-		virtual void apply(int n, TYPE *inout);
-		virtual InPlaceFilter<TYPE>* clone() const;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	private:
 		TYPE _minimum;
@@ -88,8 +88,8 @@ class Max : public MinMax<TYPE> {
 
 	public:
 		// apply filter to data vector **in*place**
-		virtual void apply(int n, TYPE *inout);
-		virtual InPlaceFilter<TYPE>* clone() const;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE>* clone() const override;
 
 	private:
 		TYPE _maximum;

--- a/libs/seiscomp/math/filter/op2filter.h
+++ b/libs/seiscomp/math/filter/op2filter.h
@@ -43,17 +43,17 @@ class Op2Filter : public InPlaceFilter<TYPE>
 	//  Derived filter interface
 	// ------------------------------------------------------------------
 	public:
-		virtual void apply(int n, TYPE *inout);
+		void apply(int n, TYPE *inout) override;
 
-		virtual void setStartTime(const Core::Time &time);
-		virtual void setStreamID(const std::string &net,
+		void setStartTime(const Core::Time &time) override;
+		void setStreamID(const std::string &net,
 		                         const std::string &sta,
 		                         const std::string &loc,
-		                         const std::string &cha);
-		virtual void setSamplingFrequency(double fsamp);
-		virtual int setParameters(int n, double const *params);
+		                         const std::string &cha) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, double const *params) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const;
+		InPlaceFilter<TYPE>* clone() const override;
 
 
 	// ------------------------------------------------------------------

--- a/libs/seiscomp/math/filter/rmhp.cpp
+++ b/libs/seiscomp/math/filter/rmhp.cpp
@@ -64,6 +64,22 @@ void RunningMean<TYPE>::apply(int n, TYPE *inout) {
 }
 
 template<typename TYPE>
+void RunningMean<TYPE>::reset() {
+	_sampleCount = 0;
+	_average = 0;
+}
+
+template<typename TYPE>
+void RunningMean<TYPE>::setSamplingFrequency(double fsamp) {
+	if (fsamp == _samplingFrequency) return;
+
+	_samplingFrequency = fsamp;
+	_windowLengthI = int(_windowLength * _samplingFrequency);
+
+	reset();
+}
+
+template<typename TYPE>
 int RunningMean<TYPE>::setParameters(int n, const double *params) {
 	// Return an error stating that the passed parameter count
 	// does not match

--- a/libs/seiscomp/math/filter/rmhp.h
+++ b/libs/seiscomp/math/filter/rmhp.h
@@ -43,18 +43,15 @@ class RunningMean : public InPlaceFilter<TYPE> {
 		}
 
 		// apply filter to data vector **in*place**
-		void apply(int n, TYPE *inout);
-		virtual InPlaceFilter<TYPE>* clone() const;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE>* clone() const override;
+
+		void setSamplingFrequency(double fsamp) override;
+
+		int setParameters(int n, const double *params) override;
 
 		// resets the filter, i.e. erases the filter memory
-		void reset() {}
-
-		virtual void setSamplingFrequency(double fsamp) {
-			_samplingFrequency = fsamp;
-			_windowLengthI = int(_windowLength * _samplingFrequency);
-		}
-
-		virtual int setParameters(int n, const double *params);
+		void reset();
 
 
 	protected:
@@ -73,8 +70,8 @@ class RunningMeanHighPass : public RunningMean<TYPE> {
 
 	public:
 		// apply filter to data vector **in*place**
-		void apply(int n, TYPE *inout);
-		virtual InPlaceFilter<TYPE>* clone() const;
+		void apply(int n, TYPE *inout) override;
+		InPlaceFilter<TYPE>* clone() const override;
 };
 
 

--- a/libs/seiscomp/math/filter/seismometers.cpp
+++ b/libs/seiscomp/math/filter/seismometers.cpp
@@ -18,7 +18,7 @@
  ***************************************************************************/
 
 
-#include<iostream>
+#include <iostream>
 using namespace std;
 
 #include <seiscomp/math/filter/seismometers.h>

--- a/libs/seiscomp/math/filter/seismometers.h
+++ b/libs/seiscomp/math/filter/seismometers.h
@@ -23,7 +23,7 @@
 
 #include <complex>
 
-#include<seiscomp/math/filter/biquad.h>
+#include <seiscomp/math/filter/biquad.h>
 
 
 namespace Seiscomp {
@@ -120,12 +120,12 @@ class Filter : public SeismometerResponse::PolesAndZeros,
 		Filter(const Filter &other);
 
 	public:
-		virtual void setSamplingFrequency(double fsamp) override;
-		virtual int setParameters(int n, const double *params) override;
+		void setSamplingFrequency(double fsamp) override;
+		int setParameters(int n, const double *params) override;
 
-		virtual void apply(int n, T *inout) override;
+		void apply(int n, T *inout) override;
 	
-		virtual Math::Filtering::InPlaceFilter<T>* clone() const override;
+		Math::Filtering::InPlaceFilter<T>* clone() const override;
 
 	private:
 		Math::Filtering::IIR::BiquadCascade<T> _cascade;
@@ -139,8 +139,8 @@ class WWSSN_SP_Filter : public Filter<T> {
 		WWSSN_SP_Filter(const WWSSN_SP_Filter &other);
 
 	public:
-		int setParameters(int n, const double *params);
-		Math::Filtering::InPlaceFilter<T>* clone() const;
+		int setParameters(int n, const double *params) override;
+		Math::Filtering::InPlaceFilter<T>* clone() const override;
 
 		void setInput(GroundMotion input);
 };
@@ -153,8 +153,8 @@ class WWSSN_LP_Filter : public Filter<T> {
 		WWSSN_LP_Filter(const WWSSN_LP_Filter &other);
 
 	public:
-		int setParameters(int n, const double *params);
-		Math::Filtering::InPlaceFilter<T>* clone() const;
+		int setParameters(int n, const double *params) override;
+		Math::Filtering::InPlaceFilter<T>* clone() const override;
 
 		void setInput(GroundMotion input);
 };
@@ -167,8 +167,8 @@ class WoodAndersonFilter : public Filter<T> {
 		WoodAndersonFilter(const WoodAndersonFilter &other);
 
 	public:
-		int setParameters(int n, const double *params);
-		Math::Filtering::InPlaceFilter<T>* clone() const;
+		int setParameters(int n, const double *params) override;
+		Math::Filtering::InPlaceFilter<T>* clone() const override;
 
 		void setInput(GroundMotion input,
 		              SeismometerResponse::WoodAnderson::Config config = SeismometerResponse::WoodAnderson::Config());
@@ -183,8 +183,8 @@ class GenericSeismometer : public Filter<T> {
 		GenericSeismometer(const GenericSeismometer &other);
 
 	public:
-		int setParameters(int n, const double *params);
-		Math::Filtering::InPlaceFilter<T>* clone() const;
+		int setParameters(int n, const double *params) override;
+		Math::Filtering::InPlaceFilter<T>* clone() const override;
 
 		void setInput(GroundMotion input);
 
@@ -199,8 +199,8 @@ class Seismometer5secFilter : public Filter<T> {
 		Seismometer5secFilter(const Seismometer5secFilter &other);
 
 	public:
-		int setParameters(int n, const double *params);
-		Math::Filtering::InPlaceFilter<T>* clone() const;
+		int setParameters(int n, const double *params) override;
+		Math::Filtering::InPlaceFilter<T>* clone() const override;
 
 		void setInput(GroundMotion input);
 };

--- a/libs/seiscomp/math/filter/stalta.h
+++ b/libs/seiscomp/math/filter/stalta.h
@@ -48,7 +48,7 @@ class STALTA : public InPlaceFilter<TYPE> {
 		// initialization when the data arrive.
 		void setSamplingFrequency(double fsamp) override;
 
-		int setParameters(int n, const double *params);
+		int setParameters(int n, const double *params) override;
 
 		InPlaceFilter<TYPE>* clone() const override;
 
@@ -94,7 +94,7 @@ class STALTA2 : public InPlaceFilter<TYPE> {
 		// initialization when the data arrive.
 		void setSamplingFrequency(double fsamp) override;
 
-		int setParameters(int n, const double *params);
+		int setParameters(int n, const double *params) override;
 
 		InPlaceFilter<TYPE>* clone() const override;
 
@@ -146,7 +146,7 @@ class STALTA_Classic : public InPlaceFilter<TYPE> {
 		// initialization when the data arrive.
 		void setSamplingFrequency(double fsamp) override;
 
-		int setParameters(int n, const double *params);
+		int setParameters(int n, const double *params) override;
 
 		InPlaceFilter<TYPE>* clone() const override;
 

--- a/libs/seiscomp/math/filter/taper.cpp
+++ b/libs/seiscomp/math/filter/taper.cpp
@@ -18,8 +18,8 @@
  ***************************************************************************/
 
 
-#include<math.h>
-#include<seiscomp/math/filter/taper.h>
+#include <math.h>
+#include <seiscomp/math/filter/taper.h>
 
 namespace Seiscomp {
 namespace Math {
@@ -33,6 +33,17 @@ InitialTaper<TYPE>::InitialTaper(double taperLength, TYPE offset, double fsamp)
 	if ( fsamp )
 		setSamplingFrequency(fsamp);
 }
+
+template<typename TYPE>
+void InitialTaper<TYPE>::setSamplingFrequency(double fsamp) {
+	if ( _samplingFrequency == fsamp ) return;
+
+	_samplingFrequency = fsamp;
+	_taperLengthI = int(_taperLength * _samplingFrequency);
+
+	reset();
+}
+
 
 template<typename TYPE>
 int InitialTaper<TYPE>::setParameters(int n, const double *params)

--- a/libs/seiscomp/math/filter/taper.h
+++ b/libs/seiscomp/math/filter/taper.h
@@ -21,9 +21,8 @@
 #ifndef SEISCOMP_FILTERING_TAPER_H
 #define SEISCOMP_FILTERING_TAPER_H
 
-#include<vector>
-
-#include<seiscomp/math/filter.h>
+#include <vector>
+#include <seiscomp/math/filter.h>
 
 namespace Seiscomp {
 namespace Math {
@@ -43,19 +42,17 @@ class InitialTaper : public InPlaceFilter<TYPE> {
 		}
 
 		// apply filter to data vector **in*place**
-		void apply(int n, TYPE *inout);
+		void apply(int n, TYPE *inout) override;
 
-		virtual InPlaceFilter<TYPE>* clone() const;
+		InPlaceFilter<TYPE>* clone() const override;
+
+		void setSamplingFrequency(double fsamp) override;
+
+		int setParameters(int n, const double *params) override;
 
 		// resets the filter, i.e. erases the filter memory
 		void reset() { _sampleCount = 0; }
 
-		virtual void setSamplingFrequency(double fsamp) {
-			_samplingFrequency = fsamp;
-			_taperLengthI = int(_taperLength * _samplingFrequency);
-		}
-
-		virtual int setParameters(int n, const double *params);
 
 	private:
 		double _taperLength,  _samplingFrequency;


### PR DESCRIPTION
**Features and Changes**:
- Consistently reset the filter state when (re)configuring the sampling frequency. (Otherwise, calling `Seiscomp::Processing::WaveformProcessor::initFilter()` in `Seiscomp::Processing::WaveformProcessor::setupStream()` may leave filters with state in case of changing sampling frequencies.)
- Consistently apply SeisComP coding conventions with regards to virtual member functions and overrides.

Please review carefully.