### PR TITLE
scolv/ focal sphere/ quadrants colours : darker?

### DIFF
--- a/libs/seiscomp/gui/datamodel/originlocatorview.cpp
+++ b/libs/seiscomp/gui/datamodel/originlocatorview.cpp
@@ -1102,7 +1102,7 @@ class PlotWidget : public OriginLocatorPlot {
 			Math::tensor2matrix(_tensor, tmp);
 
 			_renderer.setPColor(palette().color(QPalette::Base));
-			_renderer.setTColor(palette().color(QPalette::AlternateBase));
+			_renderer.setTColor(palette().color(QPalette::Mid));
 			_renderer.setBorderColor(palette().color(QPalette::WindowText));
 			_renderer.render(_buffer, _tensor, tmp);
 
@@ -1266,7 +1266,7 @@ class PlotWidget : public OriginLocatorPlot {
 				Math::Matrix3f m;
 				Math::tensor2matrix(_tensor, m);
 				_renderer.setPColor(palette().color(QPalette::Base));
-				_renderer.setTColor(palette().color(QPalette::AlternateBase));
+				_renderer.setTColor(palette().color(QPalette::Mid));
 				_renderer.setBorderColor(palette().color(QPalette::WindowText));
 				_renderer.render(_buffer, _tensor, m);
 				_dirty = false;


### PR DESCRIPTION
As discussed in https://forum.seiscomp.de/t/scv4-scolv-focal-sphere-quadrants-colours , the colour of the unconfirmed focal sphere compression quadrants is a bit confusing. Keeping the same kind of colour than original, there are 3 other possibilities:  « Dark », « Mid » and « Midlight » (see attached). I propose to use « Mid ». 

I understand the colour for the quadrants after being confirmed is « Highlight » with a 25% blend with background color, which is good, and I don't intend to propose any change on that.

<img width="1256" alt="Capture d’écran 2021-06-02 à 15 54 53" src="https://user-images.githubusercontent.com/10435362/120497787-fc5ba880-c3be-11eb-8562-a9b6ee58144a.png">
