### PR TITLE
Correctly parse `resample` RecordStream URL

### DIFF
--- a/libs/seiscomp/io/recordstream/resample.cpp
+++ b/libs/seiscomp/io/recordstream/resample.cpp
@@ -80,17 +80,13 @@ bool Resample::setSource(const string &source) {
 	}
 
 	string name = source;
+	string service = name.substr(0, pos);
 	string addr = name.substr(pos+1);
-	name.erase(pos);
 
-	string service;
-
-	pos = name.find('?');
-	if ( pos == string::npos )
-		service = name;
-	else {
-		service = name.substr(0, pos);
-		name.erase(0, pos+1);
+	pos = addr.find('?');
+	if ( pos != string::npos ) {
+		name = addr.substr(pos+1);
+		addr.erase(pos);
 
 		vector<string> toks;
 		Core::split(toks, name.c_str(), "&");


### PR DESCRIPTION
**Changes**:
- Correctly parse the `resample` RecordStream URL (in particular, do not discard optional parameters)

I hope I got the [documentation](https://www.seiscomp.de/doc/apps/global_recordstream.html#rs-resample) right. Note that the `dec` RecordStream seems to have similar issues. If required, I'm going to fix that, too.

