### PR TITLE
[S-L2 picker]: allow to use L2 S picker on vertical componet only

### DIFF
--- a/apps/descriptions/global.xml
+++ b/apps/descriptions/global.xml
@@ -1056,9 +1056,13 @@
 			<group name="spicker">
 				<group name="L2">
 					<description>
-					L2 is an algorithm to pick S-phases based on existing P-phases. The
-					picker interface name to be used in configuration files is
-					&quot;S-L2&quot;.
+						L2 is an algorithm to pick S-phases based on existing P-phases. It works by
+						creating the L2 norm of the two filtered horizontal components and then running
+						the `detecFilter` on the L2 trace to find the S pick. Finally AIC is applied
+						around the detected pick time to refine the detection. The picker name to be used
+						in configuration files is &quot;S-L2&quot;. It is also possible to run this
+						secondary picker on the vertical component only, in that case the picker name
+						to use is &quot;S-L2V&quot;
 					</description>
 					<parameter name="noiseBegin" type="double" default="-10" unit="s">
 						<description>
@@ -1083,14 +1087,16 @@
 					</parameter>
 					<parameter name="filter" type="string" default="BW(4,0.3,1.0)">
 						<description>
-						Configures the filter used to compute the L2 and to pick
-						the onset (with AIC) after the detector triggered.
+							Configures the filter used to process the horizontal components traces
+							before computing the L2-norm. For S-L2V picker the filter is applied to
+							the vertical component
 						</description>
 					</parameter>
 					<parameter name="detecFilter" type="string" default="STALTA(1,10)">
 						<description>
-						Configures the detector in the filtered L2. This filter is
-						applied on top of the base L2 filter.
+							Configures the detector filter. For S-L2 picker it is applied on the
+							filtered L2 trace, for S-L2V picker this is applied on filtered
+							vertical component data.
 						</description>
 					</parameter>
 					<parameter name="threshold" type="double" default="3">

--- a/libs/seiscomp/processing/operator/ncomps.h
+++ b/libs/seiscomp/processing/operator/ncomps.h
@@ -165,6 +165,29 @@ class StreamConfigWrapper {
 };
 
 
+template <typename T, int N>
+class NoOpWrapper {
+	public:
+		NoOpWrapper(Stream configs[N]) : _configs(configs) { }
+
+		// Process N traces in place of length n
+		void operator()(const Record *, T *data[N], int n, const Core::Time &stime, double sfreq) const {}
+
+		// publishs a processed component
+		bool publish(int c) const { return c < N; }
+
+		// Returns the component index of a given channel code
+		int compIndex(const std::string &code) const {
+			for ( int i = 0; i < N; ++i )
+				if ( code == _configs[i].code() ) return i;
+			return -1;
+		}
+
+	private:
+		const Stream *_configs;
+};
+
+
 }
 
 }

--- a/libs/seiscomp/processing/secondarypicker/S_l2.h
+++ b/libs/seiscomp/processing/secondarypicker/S_l2.h
@@ -88,6 +88,9 @@ class SC_SYSTEM_CLIENT_API SL2Picker : public SecondaryPicker {
 		const DoubleArray &processedData() const { return _detectionTrace; }
 
 	protected:
+		//! C'tor
+		SL2Picker(const std::string& methodID);
+
 		bool applyConfig();
 		void fill(size_t n, double *samples) override;
 		void process(const Record *rec, const DoubleArray &filteredData) override;
@@ -100,6 +103,7 @@ class SC_SYSTEM_CLIENT_API SL2Picker : public SecondaryPicker {
 		Filter     *_compFilter;
 		bool        _saveIntermediate;
 		DoubleArray _detectionTrace;
+		const std::string _methodID;
 };
 
 


### PR DESCRIPTION
I would like to propose this change that would allow the S-Picker L2 to work on the vertical component. My use case it that I have sensors with a single component only and some other sensors with 3 components, but whose orientation is not known. On both cases the current L2 picker cannot work because it requires 2 horizontal components to compute the L2-norm