### PR TITLE
Mwp bugfix

### DIFF
--- a/libs/seiscomp/seismology/magnitudes.h
+++ b/libs/seiscomp/seismology/magnitudes.h
@@ -50,7 +50,7 @@ bool compute_Mwp(
 //	double slope=1./1.6,
 	double alpha=7900.,
 	double rho=3400.,
-	double fp=1.);
+	double fp=0.52);
 
 
 


### PR DESCRIPTION
The default radiation pattern was 1.0 but should have been 0.52 according to Tsuboi et al. (1995). This is fixed in this PR.