### PR TITLE
[exporter] Fix broken unicode XML

### DIFF
--- a/libs/seiscomp/io/exporter.cpp
+++ b/libs/seiscomp/io/exporter.cpp
@@ -59,25 +59,10 @@ struct SinkBuf : std::streambuf {
 		if ( pbase() == pptr() ) return 0;
 
 		int bytes = pptr() - pbase();
-		int keepbytes = 0;
-
-		// UTF-8 character can take up to 4 bytes.
-		// Avoid breaking the characters.
-		while (bytes > 0 && (pbase()[bytes - 1] & 0xc0) == 0x80 && keepbytes < 4) {
-			++keepbytes;
-			--bytes;
-		}
-
 		pbase()[bytes] = '\0';
 		int res = sink->write(pbase(), bytes);
 		// Reset put pointer
 		setp(out, out + N);
-
-		if (keepbytes > 0) {
-			memcpy(pbase(), pbase() + bytes, keepbytes);
-			pbump(keepbytes);
-		}
-
 		return res == bytes ? 0 : 1;
 	}
 

--- a/libs/swig/io.i
+++ b/libs/swig/io.i
@@ -94,6 +94,10 @@
   }
 }
 
+%typemap(directorin) (const char *data, int size) {
+    $input = PyBytes_FromStringAndSize($1, $2);
+}
+
 %import "math.i"
 %include "seiscomp/core.h"
 %include "seiscomp/io/database.h"

--- a/libs/swig/io_python_wrap.cxx
+++ b/libs/swig/io_python_wrap.cxx
@@ -5755,9 +5755,7 @@ int SwigDirector_ExportSink::write(char const *data, int size) {
   int c_result = SwigValueInit< int >() ;
   
   swig::SwigVar_PyObject obj0;
-  obj0 = SWIG_FromCharPtr((const char *)data);
-  swig::SwigVar_PyObject obj1;
-  obj1 = SWIG_From_int(static_cast< int >(size));
+  obj0 = PyBytes_FromStringAndSize(data, size);
   if (!swig_get_self()) {
     Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call ExportSink.__init__.");
   }
@@ -5765,10 +5763,10 @@ int SwigDirector_ExportSink::write(char const *data, int size) {
   const size_t swig_method_index = 0;
   const char *const swig_method_name = "write";
   PyObject *method = swig_get_method(swig_method_index, swig_method_name);
-  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+  swig::SwigVar_PyObject result = PyObject_CallFunctionObjArgs(method ,(PyObject *)obj0, NULL);
 #else
   swig::SwigVar_PyObject swig_method_name = SWIG_Python_str_FromChar("write");
-  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0,(PyObject *)obj1, NULL);
+  swig::SwigVar_PyObject result = PyObject_CallMethodObjArgs(swig_get_self(), (PyObject *) swig_method_name ,(PyObject *)obj0, NULL);
 #endif
   if (!result) {
     PyObject *error = PyErr_Occurred();


### PR DESCRIPTION
Change ExportSink.write(unicode, length) to ExportSink.write(bytes) to fix unicode XML.