### PR TITLE
Comment code for future reference

### DIFF
--- a/libs/seiscomp/io/recordstream/slconnection.cpp
+++ b/libs/seiscomp/io/recordstream/slconnection.cpp
@@ -436,7 +436,7 @@ Record *SLConnection::next() {
 					SEISCOMP_DEBUG("Handshaking SeedLink server at %s", _serverloc.c_str());
 					handshake();
 					_readingData = true;
-					_retriesLeft = -1;
+					_retriesLeft = -1; // do not retry connection after handshake is completed
 				}
 				catch ( SocketTimeout &ex ) {
 					Core::msleep(500);


### PR DESCRIPTION
@gempa-jabe can we add this comment for future reference so that it is clear the current behaviour is intended?