### PR TITLE
[core]: add TTT for a homogeneous velocity model

### DIFF
--- a/apps/descriptions/global.xml
+++ b/apps/descriptions/global.xml
@@ -380,7 +380,8 @@
 			<group name="ttt">
 				<description>
 				Travel time table related configuration. Travel time tables can
-				be added via plugins. Built-in interfaces are LOCSAT and libtau.
+				be added via plugins. Built-in interfaces are LOCSAT, libtau and
+				homogeneous.
 				For each loaded interface a list of supported models must be
 				provided.
 				</description>

--- a/libs/seiscomp/seismology/ttt/CMakeLists.txt
+++ b/libs/seiscomp/seismology/ttt/CMakeLists.txt
@@ -1,4 +1,7 @@
 SET(TTT_HEADERS libtau.h locsat.h)
-SET(TTT_SOURCES libtau.cpp locsat.cpp)
+SET(TTT_SOURCES libtau.cpp locsat.cpp homogeneous.cpp)
 
 SC_SETUP_LIB_SUBDIR(TTT)
+
+FILE(GLOB descs "${CMAKE_CURRENT_SOURCE_DIR}/descriptions/*.xml")
+INSTALL(FILES ${descs} DESTINATION ${SC3_PACKAGE_APP_DESC_DIR})

--- a/libs/seiscomp/seismology/ttt/descriptions/global_homogeneous.xml
+++ b/libs/seiscomp/seismology/ttt/descriptions/global_homogeneous.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<seiscomp>
+	<plugin name="homogeneous">
+		<extends>global</extends>
+		<description>Travel time table for a homogeneous velocity model</description>
+		<configuration>
+			<group name="ttt">
+			  <group name="homogeneous">
+				<description>
+				 Travel-time interface for homogeneous velocity models.
+				</description>
+					<group name="profile" link="ttt.homogeneous.tables">
+						<description>
+							Parameters defining the area where the profile applies and the P/S velocities.
+							Once defined, the profile can then be registered in ttt.homogeneous.tables
+						</description>
+						<struct type="homogeneous profile">
+							<description></description>
+							<parameter name="origin" type="list:double" unit="deg">
+								<description>Geographic origin of the region. Expects 2 values: latitude, longitude.</description>
+							</parameter>
+							<parameter name="radius" type="double" unit="km">
+								<description>Radius validity of the region.</description>
+							</parameter>
+							<parameter name="minDepth" type="double" unit="km">
+								<description>Min Depth validity of the region.</description>
+							</parameter>
+							<parameter name="maxDepth" type="double" unit="km">
+								<description>Max Depth validity of the region.</description>
+							</parameter> 
+							<parameter name="P-velocity" type="double" unit="km/s">
+								<description>P wave velocity.</description>
+							</parameter>
+							<parameter name="S-velocity" type="double" unit="km/s">
+								<description>S wave velocity.</description>
+							</parameter>
+						</struct>
+					</group>
+				</group>
+			</group>
+		</configuration>
+	</plugin>
+</seiscomp>

--- a/libs/seiscomp/seismology/ttt/homogeneous.cpp
+++ b/libs/seiscomp/seismology/ttt/homogeneous.cpp
@@ -1,0 +1,220 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+#include <seiscomp/seismology/ttt.h>
+#include <seiscomp/core/strings.h>
+#include <seiscomp/math/geo.h>
+#include <seiscomp/datamodel/config.h>
+#include <seiscomp/system/environment.h>
+
+#include <string>
+#include <cmath>
+#include <vector>
+
+using namespace std;
+using namespace Seiscomp;
+
+namespace {
+
+/**
+ * Homogeneous
+ *
+ * A class to compute seismic travel times for an homogeneous (constant)
+ * velocity
+ */
+class Homogeneous : public TravelTimeTableInterface {
+	public:
+		/**
+		 * Construct a TravelTimeTable object for the specified model.
+		 */
+		Homogeneous() = default;
+		~Homogeneous() = default;
+
+		Homogeneous(const Homogeneous &other) = default;
+		Homogeneous &operator=(const Homogeneous &other) = default;
+
+		Homogeneous(Homogeneous &&other) = default;
+		Homogeneous &operator=(Homogeneous &&other) = default;
+
+	public:
+		bool setModel(const std::string &model) override;
+		const std::string &model() const override;
+
+		TravelTimeList *
+		compute(double lat1, double lon1, double dep1,
+		        double lat2, double lon2, double alt2 = 0.,
+		        int ellc = 1) override;
+
+		TravelTime
+		compute(const char *phase,
+		        double lat1, double lon1, double dep1,
+		        double lat2, double lon2, double alt2 = 0.,
+		        int ellc = 1) override;
+
+		TravelTime
+		computeFirst(double lat1, double lon1, double dep1,
+		             double lat2, double lon2, double alt2 = 0.,
+		             int ellc = 1) override;
+
+		bool isInside(double lat, double lon, double dep);
+
+	private:
+		std::string _model;
+		double _pVel = 1; // [km/s]
+		double _sVel = 1; // [km/s]
+		double _centerLat = 0; // [degree]
+		double _centerLon = 0; // [degree]
+		double _radius = 0; // [km]
+		double _minDepth = 0; // [km]
+		double _maxDepth = 0; // [km]
+};
+
+double radToDeg(double r) { return 180.0 * r / M_PI; }
+
+double degToRad(double d) { return M_PI * d / 180.0; }
+
+double computeDistance(double lat1, double lon1,
+                       double lat2, double lon2,
+                       double *azimuth = nullptr,
+                       double *backAzimuth = nullptr) {
+	double dist, az, baz;
+	Math::Geo::delazi(lat1, lon1, lat2, lon2, &dist, &az, &baz);
+	dist = Math::Geo::deg2km(dist);
+	if ( azimuth ) {
+		*azimuth = az;
+	}
+	if ( backAzimuth ) {
+		*backAzimuth = baz;
+	}
+	return dist;
+}
+
+bool Homogeneous::setModel(const string &model) {
+
+	// load global configuration
+	Config::Config cfg;
+	if ( ! Environment::Instance()->initConfig(&cfg, "") ) {
+		return false;
+	}
+
+	string base = "ttt.homogeneous.profile." + model + ".";
+	vector<string> origin;
+	try {
+		_pVel      = cfg.getDouble(base + "P-velocity");
+		_sVel      = cfg.getDouble(base + "S-velocity");
+		_radius    = cfg.getDouble(base + "radius");
+		_minDepth  = cfg.getDouble(base + "minDepth");
+		_maxDepth  = cfg.getDouble(base + "maxDepth");
+		origin = cfg.getStrings(base + "origin");
+	}
+	catch (...) {
+		return false;
+	}
+
+	if ( origin.size() != 2                         ||
+	   ! Core::fromString(_centerLat, origin.at(0)) ||
+	   ! Core::fromString(_centerLon, origin.at(1)) ) {
+		return false;
+	}
+
+	_model = model;
+	return true;
+}
+
+const string &Homogeneous::model() const {
+	return _model;
+}
+
+TravelTimeList *
+Homogeneous::compute(double lat1, double lon1, double dep1,
+                     double lat2, double lon2, double alt2, int ellc) {
+	TravelTimeList *ttlist = new TravelTimeList;
+	ttlist->delta = computeDistance(lat1, lon1, lat2, lon2);
+	ttlist->depth = dep1;
+	try {
+		ttlist->push_back(compute("P", lat1, lon1, dep1, lat2, lon2,  alt2, ellc));
+	}
+	catch (const NoPhaseError& e ) { }
+	try {
+		ttlist->push_back(compute("S", lat1, lon1, dep1, lat2, lon2,  alt2, ellc));
+	}
+	catch (const NoPhaseError& e ) { }
+	ttlist->sortByTime();
+	return ttlist;
+}
+
+bool
+Homogeneous::isInside(double lat, double lon, double dep)
+{
+	if ( dep < _minDepth || dep > _maxDepth ) {
+		return false;
+	}
+	double dist = computeDistance(lat, lon, _centerLat, _centerLon);
+	if ( dist > _radius ) {
+		return false;
+	}
+	return true;
+}
+
+TravelTime
+Homogeneous::compute(const char *phase,
+                     double lat1, double lon1, double dep1,
+                     double lat2, double lon2, double alt2, int ellc) {
+	double velocity;
+	if ( phase[0] == 'P' || phase[0] == 'p' ) {
+		velocity = _pVel;
+	}
+	else if ( phase[0] == 'S' || phase[0] == 's' ) {
+		velocity = _sVel;
+	}
+	else {
+		throw NoPhaseError();
+	}
+
+	if ( !isInside(lat1, lon1, dep1) ) {
+		throw NoPhaseError();
+	}
+
+	// straight ray path since we are in a homogeneous media
+	double Hdist = computeDistance(lat1, lon1, lat2, lon2);
+	double Vdist = dep1 + alt2/1000.;
+	double distance = sqrt(Hdist*Hdist + Vdist*Vdist); // [km]
+	double tt = distance / velocity; // [sec]
+	double takeOffAngle = atan2(Vdist, Hdist);
+	takeOffAngle += degToRad(90); // -90(down):+90(up) -> 0(down):180(up)
+	takeOffAngle = radToDeg(takeOffAngle);
+
+	return TravelTime(phase, tt, 0, 0, 0, takeOffAngle);
+}
+
+TravelTime
+Homogeneous::computeFirst(double lat1, double lon1, double dep1,
+                          double lat2, double lon2, double alt2, int ellc) {
+	if ( _pVel >= _sVel ) {
+		return compute("P", lat1, lon1, dep1, lat2, lon2,  alt2, ellc);
+	}
+	else {
+		return compute("S", lat1, lon1, dep1, lat2, lon2,  alt2, ellc);
+	}
+}
+
+REGISTER_TRAVELTIMETABLE(Homogeneous, "homogeneous");
+
+}
+


### PR DESCRIPTION
Dear developers,

this is a proposal to add a new travel time table for a homogeneous velocity model. This is clearly a niche use case, but since I needed it I thought to share the code and make it available to other users. This is also useful for certain testing cases, for example when developing new modules or for generating unit testing code.

If you are interested in merging this PR you might be want to review the interface name, currently `homogeneous` and how the model name is currently used ("abused") to pass the constant P and S velocity to the model. This is clearly an abuse of the model name, but it is very convenient for the user.

Currently it looks like the following:

![image](https://user-images.githubusercontent.com/15273575/177983330-02529603-03ab-4015-9350-68ddfefe28d7.png)

Luca