### PR TITLE
[GUI] allow theoretical arrivals with negative depth in picker/amplitude guis

### DIFF
--- a/libs/seiscomp/gui/datamodel/amplitudeview.cpp
+++ b/libs/seiscomp/gui/datamodel/amplitudeview.cpp
@@ -4271,8 +4271,6 @@ bool AmplitudeView::addTheoreticalArrivals(RecordViewItem *item,
 			depth = 0.0;
 		}
 
-		if ( depth <= 0.0 ) depth = 1.0;
-
 		TravelTimeList* ttt = SC_D.ttTable->compute(elat, elon, depth, slat, slon, salt);
 
 		if ( ttt ) {

--- a/libs/seiscomp/gui/datamodel/pickerview.cpp
+++ b/libs/seiscomp/gui/datamodel/pickerview.cpp
@@ -4896,8 +4896,6 @@ bool PickerView::addTheoreticalArrivals(RecordViewItem* item,
 			depth = 0.0;
 		}
 
-		if ( depth <= 0.0 ) depth = 1.0;
-
 		TravelTimeList* ttt = SC_D.ttTable->compute(elat, elon, depth, slat, slon, salt);
 
 		if ( ttt ) {


### PR DESCRIPTION
This is related to issue #66 

The code forces same depth of libtau 0.01 km. That is for consistency