### PR TITLE
Feature/update flinn engdahl region names

### DIFF
--- a/libs/seiscomp/seismology/regions/fedata/names.asc
+++ b/libs/seiscomp/seismology/regions/fedata/names.asc
@@ -19,7 +19,7 @@ Southern Yukon Territory, Canada
 Southeastern Alaska
 Off Coast of Southeastern Alaska
 West of Vancouver Island
-Queen Charlotte Islands Region
+Haida Gwaii Region
 British Columbia, Canada
 Alberta, Canada
 Vancouver Island, Canada Region

--- a/libs/seiscomp/seismology/regions/fedata/names.asc
+++ b/libs/seiscomp/seismology/regions/fedata/names.asc
@@ -193,16 +193,16 @@ New Britain Region, P.N.G.
 Solomon Islands
 D'Entrecasteaux Islands Region
 South of Solomon Islands
-Irian Jaya Region, Indonesia
-Near North Coast of Irian Jaya
+West Papua Region, Indonesia
+Near North Coast of West Papua
 Ninigo Islands Region, P.N.G.
 Admiralty Islands Region, P.N.G.
 Near N. Coast of New Guinea, PNG.
-Irian Jaya, Indonesia
+West Papua, Indonesia
 New Guinea, Papua New Guinea
 Bismarck Sea
 Aru Islands Region, Indonesia
-Near South Coast of Irian Jaya
+Near South Coast of West Papua
 Near S. Coast of New Guinea, PNG.
 Eastern New Guinea Reg., P.N.G.
 Arafura Sea

--- a/libs/seiscomp/seismology/regions/ferdata.h
+++ b/libs/seiscomp/seismology/regions/ferdata.h
@@ -415,7 +415,7 @@ static const char* feGeoRegionsNames[757] =
 /*  19 */	"Southeastern Alaska",
 /*  20 */	"Off Coast of Southeastern Alaska",
 /*  21 */	"West of Vancouver Island",
-/*  22 */	"Queen Charlotte Islands Region",
+/*  22 */	"Haida Gwaii Region",
 /*  23 */	"British Columbia, Canada",
 /*  24 */	"Alberta, Canada",
 /*  25 */	"Vancouver Island, Canada Region",


### PR DESCRIPTION
The Queen Charlotte Islands were renamed Haida Gwaii in 2010. See https://en.wikipedia.org/wiki/Haida_Gwaii#Naming. This should be reflected in the names of the Flinn Engdahl regions, out of respect for the Haida people.

This issue is mentioned in https://github.com/SeisComP/common/pull/63, but not fixed in the associated pull request.

I have updated both names.asc and the ferdata.h, including the name change of Irian Jaya to West Papua described in https://github.com/SeisComP/common/pull/63. Although I suspect only the latter is used by SeisComP, the former could be useful to other organizations.