### PR TITLE
[xml] Always include preferred magnitude in quakeML generated with XSLT

### DIFF
--- a/libs/xml/0.10/sc3ml_0.10__quakeml_1.2.xsl
+++ b/libs/xml/0.10/sc3ml_0.10__quakeml_1.2.xsl
@@ -176,6 +176,9 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 11.10.2022: Always output preferred magnitude (even when containing
+ *                origin is not referenced by event)
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -218,8 +221,19 @@
 
     <!-- event -->
     <xsl:template match="scs:event">
+        <xsl:variable name="event" select="." />
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
+
+            <!-- search for preferred magnitude so we can output it
+                 even if its containing origin is not included -->
+            <xsl:for-each select="../scs:origin">
+                <xsl:for-each select="scs:magnitude[@publicID=$event/scs:preferredMagnitudeID]">
+                    <xsl:apply-templates select="." mode="originMagnitude">
+                        <xsl:with-param name="oID" select="../@publicID"/>
+                    </xsl:apply-templates>
+                </xsl:for-each>
+            </xsl:for-each>
 
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
@@ -243,8 +257,8 @@
                         </xsl:apply-templates>
                     </xsl:for-each>
 
-                    <!-- magnitudes -->
-                    <xsl:for-each select="scs:magnitude">
+                    <!-- magnitudes, except the preferred magnitude (which we already handled) -->
+                    <xsl:for-each select="scs:magnitude[not(@publicID=$event/scs:preferredMagnitudeID)]">
                         <xsl:apply-templates select="." mode="originMagnitude">
                             <xsl:with-param name="oID" select="../@publicID"/>
                         </xsl:apply-templates>

--- a/libs/xml/0.12/sc3ml_0.12__quakeml_1.2.xsl
+++ b/libs/xml/0.12/sc3ml_0.12__quakeml_1.2.xsl
@@ -195,6 +195,9 @@
  *      'bomb detonation', 'moving aircraft' and 'atmospheric meteor explosion'
  *      to QuakeML 'other event'.
  *
+ *  * 11.10.2022: Always output preferred magnitude (even when containing
+ *                origin is not referenced by event)
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -237,8 +240,19 @@
 
     <!-- event -->
     <xsl:template match="scs:event">
+        <xsl:variable name="event" select="." />
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
+
+            <!-- search for preferred magnitude so we can output it
+                 even if its containing origin is not included -->
+            <xsl:for-each select="../scs:origin">
+                <xsl:for-each select="scs:magnitude[@publicID=$event/scs:preferredMagnitudeID]">
+                    <xsl:apply-templates select="." mode="originMagnitude">
+                        <xsl:with-param name="oID" select="../@publicID"/>
+                    </xsl:apply-templates>
+                </xsl:for-each>
+            </xsl:for-each>
 
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
@@ -262,8 +276,8 @@
                         </xsl:apply-templates>
                     </xsl:for-each>
 
-                    <!-- magnitudes -->
-                    <xsl:for-each select="scs:magnitude">
+                    <!-- magnitudes, except the preferred magnitude (which we already handled) -->
+                    <xsl:for-each select="scs:magnitude[not(@publicID=$event/scs:preferredMagnitudeID)]">
                         <xsl:apply-templates select="." mode="originMagnitude">
                             <xsl:with-param name="oID" select="../@publicID"/>
                         </xsl:apply-templates>

--- a/libs/xml/0.6/sc3ml_0.6__quakeml_1.2.xsl
+++ b/libs/xml/0.6/sc3ml_0.6__quakeml_1.2.xsl
@@ -176,6 +176,9 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 11.10.2022: Always output preferred magnitude (even when containing
+ *                origin is not referenced by event)
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -218,8 +221,19 @@
 
     <!-- event -->
     <xsl:template match="scs:event">
+        <xsl:variable name="event" select="." />
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
+
+            <!-- search for preferred magnitude so we can output it
+                 even if its containing origin is not included -->
+            <xsl:for-each select="../scs:origin">
+                <xsl:for-each select="scs:magnitude[@publicID=$event/scs:preferredMagnitudeID]">
+                    <xsl:apply-templates select="." mode="originMagnitude">
+                        <xsl:with-param name="oID" select="../@publicID"/>
+                    </xsl:apply-templates>
+                </xsl:for-each>
+            </xsl:for-each>
 
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
@@ -243,8 +257,8 @@
                         </xsl:apply-templates>
                     </xsl:for-each>
 
-                    <!-- magnitudes -->
-                    <xsl:for-each select="scs:magnitude">
+                    <!-- magnitudes, except the preferred magnitude (which we already handled) -->
+                    <xsl:for-each select="scs:magnitude[not(@publicID=$event/scs:preferredMagnitudeID)]">
                         <xsl:apply-templates select="." mode="originMagnitude">
                             <xsl:with-param name="oID" select="../@publicID"/>
                         </xsl:apply-templates>

--- a/libs/xml/0.7/sc3ml_0.7__quakeml_1.2.xsl
+++ b/libs/xml/0.7/sc3ml_0.7__quakeml_1.2.xsl
@@ -176,6 +176,9 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 11.10.2022: Always output preferred magnitude (even when containing
+ *                origin is not referenced by event)
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -218,8 +221,19 @@
 
     <!-- event -->
     <xsl:template match="scs:event">
+        <xsl:variable name="event" select="." />
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
+
+            <!-- search for preferred magnitude so we can output it
+                 even if its containing origin is not included -->
+            <xsl:for-each select="../scs:origin">
+                <xsl:for-each select="scs:magnitude[@publicID=$event/scs:preferredMagnitudeID]">
+                    <xsl:apply-templates select="." mode="originMagnitude">
+                        <xsl:with-param name="oID" select="../@publicID"/>
+                    </xsl:apply-templates>
+                </xsl:for-each>
+            </xsl:for-each>
 
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
@@ -243,8 +257,8 @@
                         </xsl:apply-templates>
                     </xsl:for-each>
 
-                    <!-- magnitudes -->
-                    <xsl:for-each select="scs:magnitude">
+                    <!-- magnitudes, except the preferred magnitude (which we already handled) -->
+                    <xsl:for-each select="scs:magnitude[not(@publicID=$event/scs:preferredMagnitudeID)]">
                         <xsl:apply-templates select="." mode="originMagnitude">
                             <xsl:with-param name="oID" select="../@publicID"/>
                         </xsl:apply-templates>

--- a/libs/xml/0.8/sc3ml_0.8__quakeml_1.2.xsl
+++ b/libs/xml/0.8/sc3ml_0.8__quakeml_1.2.xsl
@@ -176,6 +176,9 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 11.10.2022: Always output preferred magnitude (even when containing
+ *                origin is not referenced by event)
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -218,8 +221,19 @@
 
     <!-- event -->
     <xsl:template match="scs:event">
+        <xsl:variable name="event" select="." />
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
+
+            <!-- search for preferred magnitude so we can output it
+                 even if its containing origin is not included -->
+            <xsl:for-each select="../scs:origin">
+                <xsl:for-each select="scs:magnitude[@publicID=$event/scs:preferredMagnitudeID]">
+                    <xsl:apply-templates select="." mode="originMagnitude">
+                        <xsl:with-param name="oID" select="../@publicID"/>
+                    </xsl:apply-templates>
+                </xsl:for-each>
+            </xsl:for-each>
 
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
@@ -243,8 +257,8 @@
                         </xsl:apply-templates>
                     </xsl:for-each>
 
-                    <!-- magnitudes -->
-                    <xsl:for-each select="scs:magnitude">
+                    <!-- magnitudes, except the preferred magnitude (which we already handled) -->
+                    <xsl:for-each select="scs:magnitude[not(@publicID=$event/scs:preferredMagnitudeID)]">
                         <xsl:apply-templates select="." mode="originMagnitude">
                             <xsl:with-param name="oID" select="../@publicID"/>
                         </xsl:apply-templates>

--- a/libs/xml/0.9/sc3ml_0.9__quakeml_1.2.xsl
+++ b/libs/xml/0.9/sc3ml_0.9__quakeml_1.2.xsl
@@ -176,6 +176,9 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 11.10.2022: Always output preferred magnitude (even when containing
+ *                origin is not referenced by event)
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -218,8 +221,19 @@
 
     <!-- event -->
     <xsl:template match="scs:event">
+        <xsl:variable name="event" select="." />
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
+
+            <!-- search for preferred magnitude so we can output it
+                 even if its containing origin is not included -->
+            <xsl:for-each select="../scs:origin">
+                <xsl:for-each select="scs:magnitude[@publicID=$event/scs:preferredMagnitudeID]">
+                    <xsl:apply-templates select="." mode="originMagnitude">
+                        <xsl:with-param name="oID" select="../@publicID"/>
+                    </xsl:apply-templates>
+                </xsl:for-each>
+            </xsl:for-each>
 
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
@@ -243,8 +257,8 @@
                         </xsl:apply-templates>
                     </xsl:for-each>
 
-                    <!-- magnitudes -->
-                    <xsl:for-each select="scs:magnitude">
+                    <!-- magnitudes, except the preferred magnitude (which we already handled) -->
+                    <xsl:for-each select="scs:magnitude[not(@publicID=$event/scs:preferredMagnitudeID)]">
                         <xsl:apply-templates select="." mode="originMagnitude">
                             <xsl:with-param name="oID" select="../@publicID"/>
                         </xsl:apply-templates>


### PR DESCRIPTION
When an event's preferredMagnitude is contained in an origin that is not referenced by the event, this magnitude is omitted from QuakeML output.  For example, this is the case when dealing with scml produced by `scxmldump -fpFMAP` for an event with a moment magnitude preferred.

There's a note in the code that "every node not referenced by an event will be lost during the conversion", but I think this case is particularly counterintuitive because the magnitude *is* referenced by the event. Since magnitudes are direct children of events in QuakeML, I think this change makes sense.