### PR TITLE
[xml] Improve performance in scml to quakeml XSLT

### DIFF
--- a/libs/xml/0.10/sc3ml_0.10__quakeml_1.2.xsl
+++ b/libs/xml/0.10/sc3ml_0.10__quakeml_1.2.xsl
@@ -176,6 +176,8 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -251,14 +253,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.11/sc3ml_0.11__quakeml_1.2.xsl
+++ b/libs/xml/0.11/sc3ml_0.11__quakeml_1.2.xsl
@@ -182,6 +182,8 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -257,14 +259,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.12/sc3ml_0.12__quakeml_1.2.xsl
+++ b/libs/xml/0.12/sc3ml_0.12__quakeml_1.2.xsl
@@ -195,6 +195,8 @@
  *      'bomb detonation', 'moving aircraft' and 'atmospheric meteor explosion'
  *      to QuakeML 'other event'.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -270,14 +272,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.5/sc3ml_0.5__quakeml_1.2.xsl
+++ b/libs/xml/0.5/sc3ml_0.5__quakeml_1.2.xsl
@@ -172,6 +172,8 @@
  *
  *  * 10.12.2018: Put the non-QuakeML nodes in a custom namespace
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -247,14 +249,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.6/sc3ml_0.6__quakeml_1.2.xsl
+++ b/libs/xml/0.6/sc3ml_0.6__quakeml_1.2.xsl
@@ -176,6 +176,8 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -251,14 +253,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.7/sc3ml_0.7__quakeml_1.2.xsl
+++ b/libs/xml/0.7/sc3ml_0.7__quakeml_1.2.xsl
@@ -176,6 +176,8 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -251,14 +253,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.8/sc3ml_0.8__quakeml_1.2.xsl
+++ b/libs/xml/0.8/sc3ml_0.8__quakeml_1.2.xsl
@@ -176,6 +176,8 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -251,14 +253,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>

--- a/libs/xml/0.9/sc3ml_0.9__quakeml_1.2.xsl
+++ b/libs/xml/0.9/sc3ml_0.9__quakeml_1.2.xsl
@@ -176,6 +176,8 @@
  *    - Skip originUncertaintyDescription if value is set to
  *      'probability density function' not supported by QuakeML.
  *
+ *  * 31.10.2022: Improve performance when processing origins with many arrivals.
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -251,14 +253,10 @@
                     </xsl:for-each>
 
                     <!-- picks, referenced by arrivals -->
-                    <xsl:for-each select="scs:arrival">
-                        <!--xsl:value-of select="scs:pickID"/-->
-                        <!-- Don't copy picks already referenced in amplitudes -->
-                        <xsl:for-each select="
-                                ../../scs:pick[
-                                    @publicID=current()/scs:pickID
-                                    and not(@publicID=../scs:amplitude[
-                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
+                    <!-- we exclude picks already referenced in amplitudes: -->
+                    <xsl:variable name="amplitudes" select="../scs:amplitude[@publicID=$origin/scs:stationMagnitude/scs:amplitudeID]" />
+                    <xsl:for-each select="scs:arrival[not(./scs:pickID=$amplitudes/scs:pickID)]">
+                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>


### PR DESCRIPTION
SCML documents describing large earthquakes were taking a long time to convert to QuakeML, with almost all that time being spent in the loop that outputs picks that aren't referenced by amplitudes. (For example, an event with ~600 arrivals in its preferred origin was taking 12 seconds.)

By precomputing the list of referenced amplitudes once per origin (rather than computing it on the fly for each pick), performance is greatly improved (down to 400ms in my 600-arrival example).

I've got another PR open touching the same files (#72), but I figured I'd keep this separate because it doesn't change the output.