### PR TITLE
[butterworth filter] fix check on nyquist frequency

### DIFF
--- a/libs/seiscomp/math/filter/butterworth.cpp
+++ b/libs/seiscomp/math/filter/butterworth.cpp
@@ -354,7 +354,7 @@ void init_bw_biquads_inplace(Biquads &biquads, size_t order, double fmin, double
 			if ( fmax <= 0.0 )
 				throw std::runtime_error("High frequency cutoff must be greater than zero");
 
-			if ( fmax >= fnyquist )
+			if ( fmax > fnyquist )
 				throw std::runtime_error("High frequency cutoff must be lower than Nyquist frequency");
 
 			break;
@@ -363,7 +363,7 @@ void init_bw_biquads_inplace(Biquads &biquads, size_t order, double fmin, double
 			if ( fmin <= 0.0 )
 				throw std::runtime_error("Low frequency cutoff must be greater than zero");
 
-			if ( fmin >= fnyquist )
+			if ( fmin > fnyquist )
 				throw std::runtime_error("Low frequency cutoff must be lower than Nyquist frequency");
 
 			break;


### PR DESCRIPTION
I have some data with a sampling rate of 2000hz and I used a butterworth filter of 100~1000hz. The code complained about the 1000hz (`frequency cutoff must be lower than Nyquist frequency`). I might be wrong, but shouldn't 1000hz be valid?