### PR TITLE
[ttt] add computation of dtdd/dtdh in homogeneous

### DIFF
--- a/libs/seiscomp/seismology/ttt/homogeneous.cpp
+++ b/libs/seiscomp/seismology/ttt/homogeneous.cpp
@@ -195,12 +195,18 @@ Homogeneous::compute(const char *phase,
 	double Hdist = computeDistance(lat1, lon1, lat2, lon2);
 	double Vdist = dep1 + alt2/1000.;
 	double distance = sqrt(Hdist*Hdist + Vdist*Vdist); // [km]
-	double tt = distance / velocity; // [sec]
-	double takeOffAngle = atan2(Vdist, Hdist);
-	takeOffAngle += degToRad(90); // -90(down):+90(up) -> 0(down):180(up)
-	takeOffAngle = radToDeg(takeOffAngle);
 
-	return TravelTime(phase, tt, 0, 0, 0, takeOffAngle);
+	double tt = distance / velocity; // [sec]
+	double takeOffAngle = atan2(Vdist, Hdist); // [rad]
+
+	double dtdd = std::cos(takeOffAngle)             // [sec/deg]
+                / Math::Geo::km2deg(velocity); 
+	double dtdh = std::sin(takeOffAngle) / velocity; // [sec/km]
+
+	takeOffAngle = radToDeg(takeOffAngle);
+	takeOffAngle += 90; // -90(down):+90(up) -> 0(down):180(up)
+
+	return TravelTime(phase, tt, dtdd, dtdh, 0, takeOffAngle);
 }
 
 TravelTime


### PR DESCRIPTION
In my previous implementation of the homogeneous ttt I didn't compute the partial derivatives because I used LOCSAT as the reference implementation, which doesn't compute them.

However I then realized that they are required if someone wants to write a locator so here is a PR that adds the missing computation.

I verified them with the values returned by libtau and they look correct.  In the tests I used source locations close to the station so that there is no reflection/refraction involved.

```
* TTT source at lat 0.05 lon 0.00 depth 1.00 Station at 0, 0, 0(ele)

libtau P      - time 0.97 takeoff 98.0 dtdd 18.981 dtdh 0.024 dddp 0.00
homogeneous P - time 0.97 takeoff 100.2 dtdd 18.858 dtdh 0.031 dddp 0.00

libtau S      - time 1.67 takeoff 99.4 dtdd 32.648 dtdh 0.048 dddp 0.00
homogeneous S - time 1.57 takeoff 100.2 dtdd 30.382 dtdh 0.049 dddp 0.00


* TTT source at lat 0.05 lon 0.10 depth 2.00 Station at 0, 0, 0(ele)

libtau P      - time 2.17 takeoff 99.0 dtdd 18.929 dtdh 0.027 dddp 0.00
homogeneous P - time 2.17 takeoff 99.1 dtdd 18.917 dtdh 0.027 dddp 0.00

libtau S      - time 3.75 takeoff 99.3 dtdd 32.646 dtdh 0.048 dddp 0.00
homogeneous S - time 3.50 takeoff 99.1 dtdd 30.478 dtdh 0.044 dddp 0.00


* TTT source at lat 0.00 lon 0.00 depth 4.00 Station at 0, 0, 0(ele)

libtau P      - time 0.69 takeoff 179.9 dtdd 0.041 dtdh 0.172 dddp 0.00
homogeneous P - time 0.69 takeoff 180.0 dtdd 0.000 dtdh 0.172 dddp 0.00

libtau S      - time 1.19 takeoff 179.7 dtdd 0.148 dtdh 0.298 dddp 0.00
homogeneous S - time 1.11 takeoff 180.0 dtdd 0.000 dtdh 0.278 dddp 0.00


* TTT source at lat 0.10 lon 0.00 depth 8.00 Station at 0, 0, 0(ele)

libtau P      - time 2.35 takeoff 126.1 dtdd 15.475 dtdh 0.102 dddp 0.00
homogeneous P - time 2.36 takeoff 125.7 dtdd 15.551 dtdh 0.101 dddp 0.00

libtau S      - time 4.11 takeoff 129.5 dtdd 25.498 dtdh 0.189 dddp 0.00
homogeneous S - time 3.80 takeoff 125.7 dtdd 25.054 dtdh 0.162 dddp 0.00

* TTT source at lat 0.00 lon 0.10 depth 16.00 Station at 0, 0, 0(ele)

libtau P      - time 3.37 takeoff 145.9 dtdd 10.709 dtdh 0.143 dddp 0.00
homogeneous P - time 3.36 takeoff 145.2 dtdd 10.931 dtdh 0.142 dddp 0.00

libtau S      - time 5.79 takeoff 145.5 dtdd 18.720 dtdh 0.245 dddp 0.00
homogeneous S - time 5.41 takeoff 145.2 dtdd 17.611 dtdh 0.228 dddp 0.00

```


```
    auto ttt1 = Seiscomp::TravelTimeTableInterface::Create("libtau");
    if (!ttt1 || !ttt1->setModel("iasp91")) {
      SEISCOMP_ERROR("Error");
      return false;
    }
    auto ttt2 = Seiscomp::TravelTimeTableInterface::Create("homogeneous");
    if (!ttt2 || !ttt2->setModel("iasp91")) {
      SEISCOMP_ERROR("Error");
      return false;
    }

    struct Delta
    {
      double lat;
      double lon;
      double depth;
    };

    vector<Delta> deltaList = {
        //
        {0.05, 0,   1},
        {0.05, 0.1, 2},
        {0,  0,     4},
        {0.1, 0,    8},
        {0.0, 0.1, 16},
        {2.0, 2.0, 10}
    };

    for ( const auto &d : deltaList )
    {
      SEISCOMP_INFO("TTT source at lat %.2f lon %.2f depth %.2f Station at 0, 0, 0(ele)",
                    d.lat, d.lon, d.depth);

      Seiscomp::TravelTime tt;
      tt =  ttt1->compute("P", d.lat, d.lon, d.depth, 0, 0, 0);
      SEISCOMP_INFO("libtau P      - time %.2f takeoff %.1f dtdd %.3f dtdh %.3f dddp %.2f",
              tt.time, tt.takeoff, tt.dtdd, tt.dtdh, tt.dddp);
      tt =  ttt2->compute("P", d.lat, d.lon, d.depth, 0, 0, 0);
      SEISCOMP_INFO("homogeneous P - time %.2f takeoff %.1f dtdd %.3f dtdh %.3f dddp %.2f",
              tt.time, tt.takeoff, tt.dtdd, tt.dtdh, tt.dddp);
      tt =  ttt1->compute("S", d.lat, d.lon, d.depth, 0, 0, 0);
      SEISCOMP_INFO("libtau S      - time %.2f takeoff %.1f dtdd %.3f dtdh %.3f dddp %.2f",
              tt.time, tt.takeoff, tt.dtdd, tt.dtdh, tt.dddp);
      tt =  ttt2->compute("S", d.lat, d.lon, d.depth, 0, 0, 0);
      SEISCOMP_INFO("homogeneous S - time %.2f takeoff %.1f dtdd %.3f dtdh %.3f dddp %.2f",
              tt.time, tt.takeoff, tt.dtdd, tt.dtdh, tt.dddp);
    }

```
