### PR TITLE
[sdsarchive] crash if used within a concurrent RS

### DIFF
--- a/libs/seiscomp/io/recordstream/sdsarchive.cpp
+++ b/libs/seiscomp/io/recordstream/sdsarchive.cpp
@@ -351,9 +351,9 @@ void SDSArchive::close() {
 	lock_guard<mutex> l(_mutex);
 	_readFiles.clear();
 	_fnames = FileQueue();
-	_curiter = IndexList::iterator();
 	_streamSet.clear();
 	_orderedRequests.clear();
+	_curiter = _orderedRequests.begin();
 	_stime = _etime = Time();
 	_curidx = nullptr;
 	_closeRequested = true;


### PR DESCRIPTION
The SDSArchive::close() leaves the class in an inconsistent class state and the next call to SDSArchive::next() crashes.

I noticed this behaviour when using `sdsarchive` within a `routing` record stream. The debugger showed the following:

![image](https://user-images.githubusercontent.com/15273575/217294581-bee3b646-eb14-4035-95f4-1be496af45c1.png)
