### PR TITLE
 [io] Fix deadlock in Concurrent recordstream

### DIFF
--- a/libs/seiscomp/io/recordstream/concurrent.cpp
+++ b/libs/seiscomp/io/recordstream/concurrent.cpp
@@ -244,6 +244,11 @@ void Concurrent::acquiThread(RecordStream *rs) {
 	}
 
 	SEISCOMP_DEBUG("Finished acquisition thread");
+
+	if ( --_nthreads == 0) {
+		SEISCOMP_DEBUG("Closing record queue");
+		_queue.close();
+	}
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -256,6 +261,12 @@ Record *Concurrent::next() {
 		_started = true;
 
 		lock_guard<mutex> lock(_mtx);
+
+		for ( size_t i = 0; i < _rsarray.size(); ++i) {
+			if ( _rsarray[i].second ) {
+				++_nthreads;
+			}
+		}
 
 		for ( size_t i = 0; i < _rsarray.size(); ++i) {
 			if ( _rsarray[i].second ) {

--- a/libs/seiscomp/io/recordstream/concurrent.h
+++ b/libs/seiscomp/io/recordstream/concurrent.h
@@ -27,7 +27,7 @@
 #include <seiscomp/io/recordstream.h>
 #include <seiscomp/core.h>
 #include <seiscomp/client/queue.h>
-
+#include <atomic>
 
 namespace Seiscomp {
 namespace RecordStream {
@@ -108,7 +108,7 @@ class SC_SYSTEM_CORE_API Concurrent : public IO::RecordStream {
 		std::vector<RecordStreamItem>  _rsarray;
 
 	private:
-		int                            _nthreads{0};
+		std::atomic<int>               _nthreads{0};
 		std::list<std::thread>         _threads;
 		Client::ThreadedQueue<Record*> _queue;
 		std::mutex                     _mtx;


### PR DESCRIPTION
When an acquisition thread terminates ( `Concurrent::acquiThread`  retuns) there is nobody closing the record queue and the main thread loops forever