### PR TITLE
[stdloc] better solutions for not well constrained events

### DIFF
--- a/libs/3rd-party/leastsquares/solver.h
+++ b/libs/3rd-party/leastsquares/solver.h
@@ -194,7 +194,7 @@ Adapter<T> solve(System &eq, std::ostringstream *solverLogs = nullptr,
   }
   solver.SetDamp(dampingFactor);
   solver.SetMaximumNumberOfIterations(numIterations ? numIterations
-                                                    : eq.numColsG * 4);
+                                                    : eq.numColsG / 2);
   const double eps = std::numeric_limits<double>::epsilon();
   solver.SetEpsilon(eps);
   solver.SetToleranceA(1e-6); // we use [km] and [sec] in the eq system, so

--- a/plugins/locator/stdloc/descriptions/global_stdloc.xml
+++ b/plugins/locator/stdloc/descriptions/global_stdloc.xml
@@ -99,7 +99,7 @@
 								if that is not available the Grid Search can be combined with
 								LeastSquares.
 							</description>
-							<parameter name="iterations" type="int" default="40">
+							<parameter name="iterations" type="int" default="20">
 								<description>
 									Number of iterations. Each iteration will use the
 									location and time from the previous Least

--- a/plugins/locator/stdloc/stdloc.cpp
+++ b/plugins/locator/stdloc/stdloc.cpp
@@ -242,7 +242,7 @@ bool StdLoc::init(const Config::Config &config) {
   defaultProf.gridSearch.cellZExtent = 5.0;
   defaultProf.gridSearch.errorType = "L1";
   defaultProf.gridSearch.maxRms = -1;
-  defaultProf.leastSquare.iterations = 40;
+  defaultProf.leastSquare.iterations = 20;
   defaultProf.leastSquare.dampingFactor = 0;
   defaultProf.leastSquare.solverType = "LSMR";
   defaultProf.usePickUncertainties = false;
@@ -917,7 +917,7 @@ void StdLoc::locateGridSearch(
             tt = _ttt->compute(phaseName, cellLat, cellLon, cellDepth,
                                sensorLat[i], sensorLon[i], sensorElev[i]);
           } catch (exception &e) {
-            SEISCOMP_ERROR("Travel Time Table error for %s@%s.%s.%s and lat "
+            SEISCOMP_WARNING("Travel Time Table error for %s@%s.%s.%s and lat "
                            "%.6f lon %.6f depth %.3f: %s",
                            pick->phaseHint().code().c_str(),
                            pick->waveformID().networkCode().c_str(),
@@ -929,7 +929,7 @@ void StdLoc::locateGridSearch(
           }
 
           if (tt.time < 0) {
-            SEISCOMP_ERROR("Travel Time Table error: data not returned for "
+            SEISCOMP_WARNING("Travel Time Table error: data not returned for "
                            "%s@%s.%s.%s and lat %.6f lon %.6f depth %.3f",
                            pick->phaseHint().code().c_str(),
                            pick->waveformID().networkCode().c_str(),
@@ -967,7 +967,7 @@ void StdLoc::locateGridSearch(
                                originTime, cellLat, cellLon, cellDepth,
                                originTime, travelTimes);
           } catch (exception &e) {
-            SEISCOMP_ERROR(
+            SEISCOMP_DEBUG(
                 "Could not get a Least Square solution (%s): skip cell",
                 e.what());
             continue;
@@ -1041,7 +1041,7 @@ void StdLoc::locateGridSearch(
   if (!std::isfinite(lowestError)) {
     throw LocatorException("Couldn't find a solution");
   }
-  SEISCOMP_INFO(
+  SEISCOMP_DEBUG(
       "Grid Search lowest error %f for lat %.6f lon %.6f depth %.3f time %s",
       lowestError, newLat, newLon, newDepth, newTime.iso().c_str());
 }
@@ -1055,7 +1055,7 @@ void StdLoc::locateLeastSquares(
     double initDepth, Core::Time initTime, double &newLat, double &newLon,
     double &newDepth, Core::Time &newTime, vector<double> &travelTimes) const {
 
-  SEISCOMP_INFO(
+  SEISCOMP_DEBUG(
       "Start Least Square with initial lat %.6f lon %.6f depth %.3f time %s",
       initLat, initLon, initDepth, initTime.iso().c_str());
 
@@ -1110,7 +1110,7 @@ void StdLoc::locateLeastSquares(
                            sensorLon[i], sensorElev[i]);
 
       } catch (exception &e) {
-        SEISCOMP_ERROR("Travel Time Table error for %s@%s.%s.%s and lat %.6f "
+        SEISCOMP_WARNING("Travel Time Table error for %s@%s.%s.%s and lat %.6f "
                        "lon %.6f depth %.3f: %s",
                        pick->phaseHint().code().c_str(),
                        pick->waveformID().networkCode().c_str(),
@@ -1120,7 +1120,7 @@ void StdLoc::locateLeastSquares(
         throw LocatorException("Travel Time Table error");
       }
       if (tt.time < 0 || (tt.time > 0 && tt.dtdd == 0 && tt.dtdh == 0)) {
-        SEISCOMP_ERROR("Travel Time Table error: data not returned for "
+        SEISCOMP_WARNING("Travel Time Table error: data not returned for "
                        "%s@%s.%s.%s and lat %.6f lon %.6f depth %.3f",
                        pick->phaseHint().code().c_str(),
                        pick->waveformID().networkCode().c_str(),
@@ -1236,7 +1236,7 @@ void StdLoc::locateLeastSquares(
     initTime = newTime;
   }
 
-  SEISCOMP_INFO(
+  SEISCOMP_DEBUG(
       "Least Square final solution lat %.6f lon %.6f depth %.3f time %s",
       newLat, newLon, newDepth, newTime.iso().c_str());
 }
@@ -1257,7 +1257,7 @@ Origin *StdLoc::createOrigin(
   ci.setCreationTime(Core::Time::GMT());
 
   Origin *origin = Origin::Create();
-  SEISCOMP_INFO("New origin publicID: %s", origin->publicID().c_str());
+  SEISCOMP_DEBUG("New origin publicID: %s", origin->publicID().c_str());
 
   origin->setCreationInfo(ci);
   origin->setEarthModelID(_tttType + ":" + _tttModel);


### PR DESCRIPTION
Change some default settings to allow better locations  on events with small amount of picks or with outliers.  That is important when using stdloc in combination with scanloc for example.

This is a minor change for well constrained locations.

Also lower level of log messages, since they might be useful only when debugging,but they are annoying when using stdloc in normal operations.