### PR TITLE
Compute mb magnitude according to the IASPEI Magnitude WG recommendations

### DIFF
--- a/libs/seiscomp/processing/amplitudeprocessor.cpp
+++ b/libs/seiscomp/processing/amplitudeprocessor.cpp
@@ -131,6 +131,8 @@ void AmplitudeProcessor::init() {
 	_config.respTaper = 5.0;
 	_config.respMinFreq = 0.00833333; // 120 secs
 	_config.respMaxFreq = 0;
+
+	_config.iaspeiAmplitudes = false;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -922,6 +924,9 @@ bool AmplitudeProcessor::setup(const Settings &settings) {
 			SEISCOMP_DEBUG("  + response maximum frequency = %.3f", _config.respMaxFreq);
 		}
 	}
+
+	try { _config.iaspeiAmplitudes = cfg->getBool("amplitudes.iaspei"); }
+	catch ( ... ) {}
 
 	return true;
 }

--- a/libs/seiscomp/processing/amplitudeprocessor.h
+++ b/libs/seiscomp/processing/amplitudeprocessor.h
@@ -83,6 +83,10 @@ class SC_SYSTEM_CLIENT_API AmplitudeProcessor : public TimeWindowProcessor {
 			double respMaxFreq;
 
 			Math::SeismometerResponse::WoodAnderson::Config woodAndersonResponse;
+
+			// If true, compute amplitudes according to the recommendations of the
+			// IASPEI CoSOI Magnitude Working Group. Currently only affects mb.
+			bool iaspeiAmplitudes;
 		};
 
 		struct Locale : Config {

--- a/libs/seiscomp/processing/amplitudes/CMakeLists.txt
+++ b/libs/seiscomp/processing/amplitudes/CMakeLists.txt
@@ -14,6 +14,7 @@ SET(AMPS_SOURCES
 	Ms20.cpp
 	Mwp.cpp
 	sbsnr.cpp
+	iaspei.cpp
 )
 
 SET(AMPS_HEADERS
@@ -29,6 +30,7 @@ SET(AMPS_HEADERS
 	msbb.h
 	Ms20.h
 	Mwp.h
+	iaspei.h
 )
 
 SC_SETUP_LIB_SUBDIR(AMPS)

--- a/libs/seiscomp/processing/amplitudes/iaspei.cpp
+++ b/libs/seiscomp/processing/amplitudes/iaspei.cpp
@@ -1,0 +1,150 @@
+#include <seiscomp/processing/amplitudes/iaspei.h>
+
+#include <vector>
+#include <complex>
+#include <cmath>
+
+#include <seiscomp/math/filter/seismometers.h>
+
+namespace Seiscomp {
+
+namespace Processing {
+
+namespace IASPEI {
+
+#include <seiscomp/math/minmax.ipp>
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool measureAmplitudePeriod(
+	std::size_t n,
+	const double *f,
+	double offset,
+	std::size_t istart,
+	std::size_t iend,
+	AmplitudePeriodMeasurement &measurement)
+{
+	// NOTE:
+	// This routine scans the input data array twice, once for the zero
+	// crossings and once for the peaks (incl. troughs!) in between.
+	// This makes the routine easier to understand but at some
+	// computational cost that in tests have shown to be irrelevant in
+	// a normal processing setup.
+
+	if ( istart >= iend || iend >= data.size() ) {
+		return false;
+	}
+
+	// Determine zero crossings.
+	std::vector<std::size_t> zero_crossings;
+	double previous { f[istart] - offset };
+	for ( std::size_t i = istart + 1; i < iend; i++ ) {
+		double current { f[i] - offset };
+		if ( current*previous <= 0 && previous != 0 ) {
+			// => zero crossing
+			// i refers to the first sample after zero crossing
+			zero_crossings.push_back(i);
+		}
+
+		previous = current;
+	}
+
+	if ( zero_crossings.size() < 3 ) {
+		return false;
+	}
+
+	// Determine peaks between zero crossings.
+	std::vector<std::size_t> peaks;
+	std::size_t nz { zero_crossings.size() };
+	for ( std::size_t k = 1; k < nz; k++ ) {
+		// The casts will never hurt in practice but should be
+		// removed after a revision of find_absmax().
+		int i1 = static_cast<int>(zero_crossings[k-1]);
+		int i2 = static_cast<int>(zero_crossings[k]);
+		std::size_t peak = find_absmax(static_cast<int>(n), f, i1, i2, offset);
+		peaks.push_back(peak);
+	}
+
+	// Keep track of the largest p2p amplitude...
+	double amax { 0 };
+	// ... and the respective index
+	std::size_t kmax { 0 };
+
+	std::size_t np = peaks.size();
+	for ( std::size_t k = 1; k < np; k++ ) {
+		std::size_t i1 { peaks[k - 1] };
+		std::size_t i2 { peaks[k] };
+
+		// New p2p maximum?
+		double a { std::abs(f[i1] - f[i2]) };
+		if ( a > amax ) {
+			kmax = k;
+			amax = a;
+		}
+	}
+
+	// The z2p peak is the larger of the two consequtive peaks
+	// comprising the maximum p2p amplitude.
+	std::size_t ip2p1 { peaks[kmax - 1] };
+	std::size_t ip2p2 { peaks[kmax] };
+	double ap2p1 { std::abs(f[ip2p1] - offset) };
+	double ap2p2 { std::abs(f[ip2p2] - offset) };
+
+	measurement.iz2p = ap2p2 > ap2p1 ? ip2p2 : ip2p1;
+	measurement.az2p = ap2p2 > ap2p1 ? ap2p2 : ap2p1;
+
+	measurement.ip2p1 = ip2p1;
+	measurement.ip2p2 = ip2p2;
+	measurement.ap2p1 = ap2p1;
+	measurement.ap2p2 = ap2p2;
+
+	return true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool measureAmplitudePeriod(
+	const std::vector<double> &data,
+	double offset,
+	std::size_t istart,
+	std::size_t iend,
+	AmplitudePeriodMeasurement &measurement)
+{
+	const double *f { &data[0] };
+	std::size_t n { data.size() };
+
+	return measureAmplitudePeriod(n, f, offset, istart, iend, measurement);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+double wwssnspAmplitudeResponse(double frequency_hz)
+{
+	using namespace Seiscomp::Math;
+	static Filtering::IIR::WWSSN_SP_Filter<double> wwssnsp(Displacement);
+	static double twopi { M_PI+M_PI };
+
+        const std::complex<double> s(0, twopi*frequency_hz);
+        std::complex<double> r { wwssnsp.norm };
+        for ( const std::complex<double> &p : wwssnsp.poles ) {
+                r = r/(s-p);
+	}
+        for ( const std::complex<double> &z : wwssnsp.zeros ) {
+                r = r*(s-z);
+	}
+        return std::abs(r);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+} // namespace IASPEI
+
+} // namespace Processing
+
+} // namespace Seiscomp
+

--- a/libs/seiscomp/processing/amplitudes/iaspei.h
+++ b/libs/seiscomp/processing/amplitudes/iaspei.h
@@ -1,0 +1,117 @@
+#ifndef SEISCOMP_PROCESSING_IASPEI_H_INCLUDED
+#define SEISCOMP_PROCESSING_IASPEI_H_INCLUDED
+
+#include <vector>
+
+namespace Seiscomp {
+
+namespace Processing {
+
+namespace IASPEI {
+
+
+// IASPEI Amplitude Measurement Procedure
+//
+// From:
+// Summary of Magnitude Working Group Recommendations on Standard Procedures
+// for Determining Earthquake Magnitudes From Digital Data - 2013 March 27
+//
+// Amplitudes [...] to be measured as one-half the maximum deflection of the
+// seismogram trace, peak-to-adjacent- trough or trough-to-adjacent-peak,
+// where peak and trough are separated by one crossing of the zero-line: the
+// measurement is sometimes described as "one-half peak-to-peak amplitude."
+// None of the magnitude formulas presented in this article are intended to
+// be used with the full peak-to-trough deflection as the amplitude. The
+// periods are to be measured as twice the time-intervals separating the
+// peak and adjacent-trough from which the amplitudes are measured.
+
+
+struct AmplitudePeriodMeasurement
+{
+	// Amplitudes
+	//
+	// Note that "peak" here refers to both maxima and minima and
+	// thus can also refer to a trough. So peak-to-peak is either
+	// peak-to-trough or trough-to-peak. Just to avoid confusion.
+	//
+	// - az2p Max. zero-to-peak amplitude found at index iz2p
+	// - ap2p1 first peak of the max. peak-to-peak amplitude pair
+	// - ap2p1 second peak 
+	//
+	// Note that az2p is the larger of ap2p1 and ap2p2.
+
+	double az2p;
+	double ap2p1;
+	double ap2p2;
+
+	// Sample indices corresponding the above peaks
+	std::size_t iz2p;
+	std::size_t ip2p1;
+	std::size_t ip2p2;
+
+	// From the above numbers we can now derive:
+	//
+	// - Period in sampling intervals:
+	//
+	//   (ip2p2 - ip2p1)*2
+	//
+	//   To be divided by the sampling rate in order to get the period
+	//   in seconds.
+	//
+	//
+	// - One half of the max. peak-to-peak amplitude in data units:
+	//
+	//   (ap2p1 + ap2p2)/2
+	//
+	//
+	// - Time of measurement as offset from first sample of the middle
+	//   of the two peaks:
+	//
+	//   (ip2p1 + ip2p2)/2
+	//
+	//   To be divided by the sampling rate in order to get the time
+	//   in seconds.
+};
+
+
+// Compute amplitude and dominant period for the given data vector.
+//
+// The data may have an offset to be removed during the amplitude measurement.
+// If dealing with demeaned data the offset should be zero.
+//
+// We only work on the time window between samples istart and iend.
+//
+// A reference to a struct AmplitudePeriodMeasurement is speciefied, where the
+// result will be written to. See above for details.
+bool measureAmplitudePeriod(
+	const std::vector<double> &data,
+	double offset,
+	std::size_t istart,
+	std::size_t iend,
+	AmplitudePeriodMeasurement &measurement);
+
+
+// Interface for raw pointer.
+bool measureAmplitudePeriod(
+	std::size_t ndata,
+	const double *data,
+	double offset,
+	std::size_t istart,
+	std::size_t iend,
+	AmplitudePeriodMeasurement &measurement);
+
+
+// Compute the WWSSN-SP displacement amplitude response needed for the
+// mb amplitude correction.
+//
+// The response is based on the poles and zeros specified in the IASPEI
+// Magnitude Working Group Recommendations.
+double wwssnspAmplitudeResponse(double frequency_hz);
+
+} // namespace IASPEI
+
+} // namespace Processing
+
+} // namespace Seiscomp
+
+#endif

--- a/libs/seiscomp/processing/amplitudes/m_B.cpp
+++ b/libs/seiscomp/processing/amplitudes/m_B.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 
 
+#include <seiscomp/datamodel/amplitude.h>
 #include <seiscomp/processing/amplitudes/m_B.h>
 #include <limits>
 
@@ -62,6 +63,24 @@ AmplitudeProcessor_mB::AmplitudeProcessor_mB(const Core::Time& trigger)
 
 
 
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void AmplitudeProcessor_mB::finalizeAmplitude(DataModel::Amplitude *amplitude) const {
+	if ( !amplitude )
+		return;
+
+	try {
+		DataModel::TimeQuantity time(amplitude->timeWindow().reference());
+		amplitude->setScalingTime(time);
+	}
+	catch ( ... ) {
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 double AmplitudeProcessor_mB::timeWindowLength(double distance) const {
 	// make sure the measurement is not contaminated by S energy
@@ -69,6 +88,8 @@ double AmplitudeProcessor_mB::timeWindowLength(double distance) const {
 	return tdist < _config.signalEnd ? tdist :_config.signalEnd;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/libs/seiscomp/processing/amplitudes/m_B.h
+++ b/libs/seiscomp/processing/amplitudes/m_B.h
@@ -35,6 +35,9 @@ class SC_SYSTEM_CLIENT_API AmplitudeProcessor_mB : public AmplitudeProcessor {
 		AmplitudeProcessor_mB();
 		AmplitudeProcessor_mB(const Core::Time& trigger);
 
+	public:
+		void finalizeAmplitude(DataModel::Amplitude *amplitude) const override;
+
 	protected:
 		double timeWindowLength(double distance) const override;
 		bool computeAmplitude(const DoubleArray &data,

--- a/libs/seiscomp/processing/amplitudes/mb.h
+++ b/libs/seiscomp/processing/amplitudes/mb.h
@@ -40,6 +40,8 @@ class SC_SYSTEM_CLIENT_API AmplitudeProcessor_mb : public AmplitudeProcessor {
 	public:
 		void initFilter(double fsamp) override;
 
+		void finalizeAmplitude(DataModel::Amplitude *amplitude) const override;
+
 	protected:
 		bool computeAmplitude(const DoubleArray &data,
 		                      size_t i1, size_t i2,


### PR DESCRIPTION
This PR implements the computation of mb according to the IASPEI Magnitude WG recommendations. There are some differences in the technique for determining the relevant extrema in the waveforms but the most notable difference is the correction by the WWSSN-SP amplitude response. This correction was not done previously and will have some effect especially for events for which the WWSSN-SP filtered P waveforms have a dominant period of more than one second. We will then observe on average a slight mb _increase_. For shorter periods mb will slightly _decrease_.

This is currently off by default and can be enabled by setting `amplitudes.iaspei = true` in the config. I am open to enable it by default, though.

Thanks to Jens Havskov for triggering this!

Note that this PR also implements a not directly related enhancement, namely the inclusion of the scaling time. At the moment only for mb and mB. The scaling time is the time at which the measurement (usually the amplitude maximum) was taken and is essential for understanding amplitude measurements (here we have the relation to mb). In principle the scaling time is contained in the amplitude time window as reference time but the more appropriate QuakeML attribute for this is the scaling time.