### PR TITLE
[io] add support for wildcards in File RecordStream

### DIFF
--- a/libs/seiscomp/io/recordstream/file.h
+++ b/libs/seiscomp/io/recordstream/file.h
@@ -28,6 +28,7 @@
 
 #include <seiscomp/io/recordstream.h>
 #include <seiscomp/core.h>
+#include <boost/regex.hpp>
 
 
 namespace Seiscomp {
@@ -115,6 +116,9 @@ class SC_SYSTEM_CORE_API File : public Seiscomp::IO::RecordStream {
 		};
 
 		typedef std::map<std::string, TimeWindowFilter> FilterMap;
+		typedef std::vector< std::pair<boost::regex,TimeWindowFilter> > ReFilterList;
+
+		const TimeWindowFilter* findTimeWindowFilter(Record *rec) const;
 
 		RecordFactory  *_factory;
 		std::string     _name;
@@ -122,6 +126,7 @@ class SC_SYSTEM_CORE_API File : public Seiscomp::IO::RecordStream {
 		std::fstream    _fstream;
 		std::istream   *_current;
 		FilterMap       _filter;
+		ReFilterList    _reFilter;
 		Core::Time      _startTime;
 		Core::Time      _endTime;
 };

--- a/libs/seiscomp/io/recordstream/file.h
+++ b/libs/seiscomp/io/recordstream/file.h
@@ -28,7 +28,6 @@
 
 #include <seiscomp/io/recordstream.h>
 #include <seiscomp/core.h>
-#include <boost/regex.hpp>
 
 
 namespace Seiscomp {
@@ -116,9 +115,9 @@ class SC_SYSTEM_CORE_API File : public Seiscomp::IO::RecordStream {
 		};
 
 		typedef std::map<std::string, TimeWindowFilter> FilterMap;
-		typedef std::vector< std::pair<boost::regex,TimeWindowFilter> > ReFilterList;
+		typedef std::vector< std::pair<std::string,TimeWindowFilter> > ReFilterList;
 
-		const TimeWindowFilter* findTimeWindowFilter(Record *rec) const;
+		const TimeWindowFilter* findTimeWindowFilter(Record *rec);
 
 		RecordFactory  *_factory;
 		std::string     _name;


### PR DESCRIPTION
File::addStream now supports * ? () |

This is related to https://github.com/SeisComP/main/pull/59 - without wildcards support that PR is of limited use.