### PR TITLE
[stdloc] add OctTree method

### DIFF
--- a/libs/3rd-party/leastsquares/solver.h
+++ b/libs/3rd-party/leastsquares/solver.h
@@ -112,10 +112,18 @@ public:
       _eq.L2NScaler[3] += _eq.G[ob][3] * _eq.G[ob][3];
     }
 
-    _eq.L2NScaler[0] = 1. / std::sqrt(_eq.L2NScaler[0]);
-    _eq.L2NScaler[1] = 1. / std::sqrt(_eq.L2NScaler[1]);
-    _eq.L2NScaler[2] = 1. / std::sqrt(_eq.L2NScaler[2]);
-    _eq.L2NScaler[3] = 1. / std::sqrt(_eq.L2NScaler[3]);
+    if (_eq.L2NScaler[0] != 0 ) {
+      _eq.L2NScaler[0] = 1. / std::sqrt(_eq.L2NScaler[0]);
+    }
+    if (_eq.L2NScaler[1] != 0 ) {
+      _eq.L2NScaler[1] = 1. / std::sqrt(_eq.L2NScaler[1]);
+    }
+    if (_eq.L2NScaler[2] != 0 ) {
+      _eq.L2NScaler[2] = 1. / std::sqrt(_eq.L2NScaler[2]);
+    }
+    if (_eq.L2NScaler[3] != 0 ) {
+      _eq.L2NScaler[3] = 1. / std::sqrt(_eq.L2NScaler[3]);
+    }
   }
 
   /*

--- a/plugins/locator/stdloc/descriptions/global_stdloc.rst
+++ b/plugins/locator/stdloc/descriptions/global_stdloc.rst
@@ -1,4 +1,6 @@
-StdLoc is a SeisComP locator plugin with focus on local seismicity.
+StdLoc is a SeisComP locator plugin that combines standard location methods
+and was developed with the focus on local seismicity, although the methods
+are generic enough to work at different scales.
 
 Plugin
 ======
@@ -9,28 +11,61 @@ To enable StdLoc the plugin ``stdloc`` must be loaded.
 How does it work?
 =================
 
-The locator can find a solution via iterative least squares, grid search or, more
-interestingly, as a mix of the two. In this latter case a coarse grid should be
-selected and an iterative least square solution is found for each cell. The solution
-with lowest error is preferred and returned. This mixed approach is interesting since
-it solves the issue of the least square method that requires an initial location
-estimate.
+The locator can apply a multitude of location methods and it is particularly useful to
+combine them to achieve better solutions.
+The methods available are: LeastSquares, GridSearch, OctTree and, more interestingly,
+two mixed methods: GridSearch+LeastSquares and OctTree+LeastSquares:
 
-A special case of this configuration is to have a grid with only one cell so that the
-least square will always start from that cell centroid. That configuration would make
-sense when,for example, monitoring working sites and the initial location is actually
-known.
+- LeastSquares: this is the classic algorithm that solve the linearized problem via
+  iterative Least Square. However an initial location estimate is required and that
+  makes its solutions dependent on a good initial location. For this reason this
+  method should be combined with GridSearch or OctTree, unless it is intended to be
+  used only as a re-locator of an existing solution e.g. in scolv or screloc
+- GridSearch: finds the source location by evaluating the hypocenter probability
+  of each grid cell and returning the maximum likelihood hypocenter.
+  The source time is derived from the weighted average of arrival travel times.
+  The downside of this method is that the resolution of the hypocenters depends on
+  the grid size, but dense grids can be very slow to compute,
+- GridSearch+LeastSquares: this method works similarly to GridSearch but it performs
+  an additional LeastSquares for each grid cell, using the cell centroid as initial
+  location estimate. This solves the major issues of both LeastSquares and
+  GridSearch: by trying multiple initial location estimates allow LeastSquares to
+  not be dependent on a bad initial location estimate and the grid doesn't need to
+  be dense, which makes the method faster than GridSearch and with higher resolution.
+  For very local seisicity monitoring it could be used with a single cell only,
+  which corresponds to starting LeastSquares from the same location with every
+  event.
+- OctTree: this method follows the NonLinLoc approach. The OctTree search starts 
+  similarly to GridSearch by evaluating the hypocenter probability of each grid cell,
+  computed as the probability density at the cell center coordinates times the cell
+  volume. The search then continues by repeatedly fetching the cell with high 
+  probability and dividing it in 8 sub-cells. These 8 cells are then inserted in the
+  pool of cells to fetch from at next iteration.
+  The search terminates after either a maximum number of iterations or after
+  reaching a minimum cell size. At that point the maximum likelihood hypocenter
+  is selected.
+- OctTree+LeastSquares: the solution can be further improved combining OctTree with
+  the Least Squares algorithm, which can use the OctTree solution as initial
+  location estimate. This allows OctTree to stop after reaching a big cell size
+  (i.e. it is fast) and letting LeastSquares to refine the solution. Knowing that
+  the initial location estimate for LeastSquares is the maximum probability cell of
+  OctTree the solution should not get stuck in a local minima. For example it is
+  possible to define a grid size that covers a whole network and set the OctTree
+  cell minimum size to a couple of kilometers. LeastSquares will then improve the
+  location resolution of that coarse grid.
 
-The algorithms implemented in StdLoc are standard methods described in 
-"Routine Data Processing in Earthquake Seismology" by Jens Havskov and
-Lars Ottemoller
+
+The algorithms implemented in StdLoc are standard methods described in "Routine Data
+Processing in Earthquake Seismology" by Jens Havskov and Lars Ottemoller. The OctTree
+search algorithm is based on NonLibLoc by Antony Lomax.
+
 
 
 Why is stdloc suitable for local seismicity?
 ============================================
 
-When dealing with very local seismicity (few kilometers or hundres of meters) common
-semplification for regional seismicity become importants. In particular the locator
+When dealing with very local seismicity (few kilometers or hundreds of meters) common
+simplification for regional seismicity become important. In particular the locator
 should take into consideration:
 - station elevation and even negative elevation (e.g. borehole sensors)
 - earthquake location can be above a seismic sensor (e.g. borehole sensors)

--- a/plugins/locator/stdloc/descriptions/global_stdloc.xml
+++ b/plugins/locator/stdloc/descriptions/global_stdloc.xml
@@ -18,12 +18,12 @@
 					<struct type="stdloc profile" link = "StdLoc.profiles">
 
 						<parameter name="method" type="string" default="GridSearch+LeastSquares">
-							<description>The location method to use: LeastSquares, GridSearch 
-							or GridSearch+LeastSquares.
+							<description>The location method to use: LeastSquares, GridSearch, OctTree,
+							 GridSearch+LeastSquares or OctTree+LeastSquares.
 							</description>
 						</parameter>
- 
-						<parameter name="tableType" type="string" default="libtau">
+
+						<parameter name="tableType" type="string" default="LOCSAT">
 							<description>Travel time table format type.</description>
 						</parameter>
 						<parameter name="tableModel" type="string" default="iasp91">
@@ -70,14 +70,16 @@
 
 						<group name="GridSearch">
 							<description>
-								The grid cell with lowest error is selected as source location and
-								the source time is derived from the average of travel time residuals.
-								The solution can be further improved enabling the Least Square
-								algorithm, which will then be run for each grid cell, using
-								the cell centroid as initial location. In this case only a few cells
-								are required, even a single one.
+								Find the source location by evaluating the hypocenter probability
+								of each grid cell and returning the maximum likelihood hypocenter.
+								The source time is derived from the weighted average of arrival
+								travel times.
+								The solution can be further improved combining it with the Least Squares
+								algorithm, which will then be run for each grid cell, using the cell
+								centroid as initial location estimate. In this case only few big cells
+								are required.
 							</description>
-							<parameter name="center" type="list:string" default="lat,lon,5">
+							<parameter name="center" type="list:string" default="auto,auto,5">
 								<description>Latitude,longitude,depth[km]. </description>
 							</parameter>
 							<parameter name="autoLatLon" type="boolean" default="true">
@@ -92,17 +94,37 @@
 							<parameter name="cellSize" type="list:string" unit="km" default="2.5,2.5,5">
 								<description>Cell X, Y, Z size in km</description>
 							</parameter>
-							<parameter name="errorType" type="string" default="L1">
-								<description>Error computation to use: L1 or L2 norm. L1 is less sensitive
-									to outliers and so more suitable with automatic picks, L2 is the preferred
-									choice for manual picks.
-							</description>
+							<parameter name="misfitType" type="string" default="L1">
+								<description>The type of misfit to use, from which the likelyhood function is
+									derived: L1 or L2 norm. L1 is less sensitive to outliers and so more 
+									suitable with automatic picks, L2 is the preferred choice for manual picks.
+								</description>
 							</parameter>
-							<parameter name="maxRms" type="double">
+							<parameter name="travelTimeError" type="double" unit="s" default="0.25">
 								<description>
-									Maxmium rms accepterd for a location: a solution with a higher value
-									will be rejected. A negative or no value means that there is no maximum
-									threshold on the RMS.
+									Typical error in seconds for travel-time to one station. This
+									value affects the uncertainty of the location.
+								</description>
+							</parameter>
+						</group>
+
+						<group name="OctTree">
+							<description>
+								Find the source location and time via OctTree search. This method uses the
+								parameters defined in GridSearch, but applies the OctTree search algorithm.
+								The solution can be further improved combining OctTree with the Least Squares
+								algorithm, which can use the OctTree solution as initial location estimate.
+							</description>
+							<parameter name="maxIterations" type="int" default="50000">
+								<description>
+									Number of iterations after which the search stops. A zero or negative
+									value disable this stopping mechanism.
+								</description>
+							</parameter> 
+							<parameter name="minCellSize" type="double" unit="km" default="0.1">
+								<description>
+									Minimum cell size to be generate by the OctTree search to stop. A zero
+									or negative value disable this stopping mechanism.
 								</description>
 							</parameter>
 						</group>
@@ -110,9 +132,9 @@
 						<group name="LeastSquares">
 							<description>
 								Find the source location and time via iterative Least Square.
-								An initial source location and time are required.
-								if that is not available the Grid Search can be combined with
-								LeastSquares.
+								However an initial location estatimate is required. if that is not
+								available then this method should be combined with GridSearch or
+								OctTree.
 							</description>
 							<parameter name="iterations" type="int" default="20">
 								<description>

--- a/plugins/locator/stdloc/stdloc.cpp
+++ b/plugins/locator/stdloc/stdloc.cpp
@@ -111,7 +111,7 @@ double computeMedian(const vector<double> &values) {
 	const auto middleItr = tmp.begin() + tmp.size() / 2;
 	nth_element(tmp.begin(), middleItr, tmp.end());
 	double median = *middleItr;
-	if (tmp.size() % 2 == 0) {
+	if ( tmp.size() % 2 == 0 ) {
 		const auto leftMiddleItr = max_element(tmp.begin(), middleItr);
 		median = (*leftMiddleItr + *middleItr) / 2;
 	}
@@ -121,8 +121,8 @@ double computeMedian(const vector<double> &values) {
 
 void computeCoordinates(double distance, double azimuth, double clat,
                         double clon, double &lat, double &lon) {
-	Math::Geo::delandaz2coord(Math::Geo::km2deg(distance), azimuth,
-	                          clat, clon, &lat, &lon);
+	Math::Geo::delandaz2coord(Math::Geo::km2deg(distance), azimuth, clat, clon,
+	                          &lat, &lon);
 	lon = Geo::GeoCoordinate::normalizeLon(lon);
 }
 
@@ -133,9 +133,9 @@ double computeDistance(double lat1, double lon1, double lat2, double lon2,
 	double dist, az, baz;
 	Math::Geo::delazi(lat1, lon1, lat2, lon2, &dist, &az, &baz);
 
-	if (azimuth)
+	if ( azimuth )
 		*azimuth = az;
-	if (backAzimuth)
+	if ( backAzimuth )
 		*backAzimuth = baz;
 
 	return dist;
@@ -143,33 +143,35 @@ double computeDistance(double lat1, double lon1, double lat2, double lon2,
 
 
 double computePickWeight(DataModel::Pick *pick,
-                         const vector<double>& uncertaintyClasses) {
+                         const vector<double> &uncertaintyClasses) {
 
 	double uncertainty = -1; // secs
 	try {
 		// symmetric uncertainty
 		uncertainty = pick->time().uncertainty();
-	} catch ( Core::ValueException & ) {
+	}
+	catch ( Core::ValueException & ) {
 		// asymmetric uncertainty
 		try {
-			uncertainty =
-					(pick->time().lowerUncertainty() + pick->time().upperUncertainty()) /
-					2.0;
-		} catch ( Core::ValueException & ) {
+			uncertainty = (pick->time().lowerUncertainty() +
+			               pick->time().upperUncertainty()) /
+			              2.0;
+		}
+		catch ( Core::ValueException & ) {
 		}
 	}
 
 	// set lowest class as default
-	unsigned uncertaintyClass = uncertaintyClasses.size()-1;
+	unsigned uncertaintyClass = uncertaintyClasses.size() - 1;
 
-	if (uncertainty >= 0 && isfinite(uncertainty) && 
-			uncertaintyClasses.size() > 1 &&
-			uncertainty < uncertaintyClasses.back() ) {
+	if ( uncertainty >= 0 && isfinite(uncertainty) &&
+	     uncertaintyClasses.size() > 1 &&
+	     uncertainty < uncertaintyClasses.back() ) {
 
-		for ( unsigned curr = 0, next = 1; 
-		      next < uncertaintyClasses.size(); curr++, next++ ) {
-			if (uncertainty >= uncertaintyClasses.at(curr) && 
-			    uncertainty <= uncertaintyClasses.at(next)) {
+		for ( unsigned curr = 0, next = 1; next < uncertaintyClasses.size();
+		      curr++, next++ ) {
+			if ( uncertainty >= uncertaintyClasses.at(curr) &&
+			     uncertainty <= uncertaintyClasses.at(next) ) {
 				uncertaintyClass = curr;
 				break;
 			}
@@ -206,12 +208,12 @@ bool invertMatrix4x4(const std::array<std::array<double,4>,4> &in,
 	double A0112 = in[1][0] * in[2][1] - in[1][1] * in[2][0];
 
 	double det =
-	  in[0][0] * (in[1][1] * A2323 - in[1][2] * A1323 + in[1][3] * A1223) -
-	  in[0][1] * (in[1][0] * A2323 - in[1][2] * A0323 + in[1][3] * A0223) +
-	  in[0][2] * (in[1][0] * A1323 - in[1][1] * A0323 + in[1][3] * A0123) -
-	  in[0][3] * (in[1][0] * A1223 - in[1][1] * A0223 + in[1][2] * A0123);
+	    in[0][0] * (in[1][1] * A2323 - in[1][2] * A1323 + in[1][3] * A1223) -
+	    in[0][1] * (in[1][0] * A2323 - in[1][2] * A0323 + in[1][3] * A0223) +
+	    in[0][2] * (in[1][0] * A1323 - in[1][1] * A0323 + in[1][3] * A0123) -
+	    in[0][3] * (in[1][0] * A1223 - in[1][1] * A0223 + in[1][2] * A0123);
 
-	if (det == 0) {
+	if ( det == 0 ) {
 		return false;
 	}
 
@@ -237,7 +239,7 @@ bool invertMatrix4x4(const std::array<std::array<double,4>,4> &in,
 	return true;
 }
 
-}
+} // namespace
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
@@ -247,7 +249,7 @@ namespace { // StdLoc implementation
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 ADD_SC_PLUGIN(
 	"Standard Locator",
-	"Luca Scarabello <luca.scarabello@erdw.ethz.ch>",
+	"Luca Scarabello, ETH Zurich",
 	1, 0, 0
 )
 REGISTER_LOCATOR(StdLoc, "StdLoc");
@@ -257,24 +259,35 @@ REGISTER_LOCATOR(StdLoc, "StdLoc");
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+int StdLoc::capabilities() const {
+	return InitialLocation | FixedDepth;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 const IDList StdLoc::_allowedParameters = {
-	"method",
-	"tttType",
-	"tttModel",
-	"PSTableOnly",
-	"usePickUncertainties",
-	"pickUncertaintyClasses",
-	"enableConfidenceEllipsoid",
-	"confLevel",
-	"GridSearch.center",
-	"GridSearch.autoLatLon",
-	"GridSearch.size",
-	"GridSearch.cellSize",
-	"GridSearch.errorType",
-	"GridSearch.maxRms",
-	"LeastSquares.iterations",
-	"LeastSquares.dampingFactor",
-	"LeastSquares.solverType",
+    "method",
+    "tttType",
+    "tttModel",
+    "PSTableOnly",
+    "usePickUncertainties",
+    "pickUncertaintyClasses",
+    "enableConfidenceEllipsoid",
+    "confLevel",
+    "GridSearch.center",
+    "GridSearch.autoLatLon",
+    "GridSearch.size",
+    "GridSearch.cellSize",
+    "GridSearch.misfitType",
+    "GridSearch.travelTimeError",
+    "OctTree.maxIterations",
+    "OctTree.minCellSize",
+    "LeastSquares.iterations",
+    "LeastSquares.dampingFactor",
+    "LeastSquares.solverType",
 };
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -292,11 +305,12 @@ bool StdLoc::init(const Config::Config &config) {
 	Profile defaultProf;
 	defaultProf.name = "";
 	defaultProf.method = Profile::Method::GridAndLsqr;
-	defaultProf.tttType = "libtau";
+	defaultProf.tttType = "LOCSAT";
 	defaultProf.tttModel = "iasp91";
 	defaultProf.PSTableOnly = true;
 	defaultProf.usePickUncertainties = false;
-	defaultProf.pickUncertaintyClasses = {0.000,0.025,0.050,0.100,0.200,0.400};
+	defaultProf.pickUncertaintyClasses = {0.000, 0.025, 0.050,
+	                                      0.100, 0.200, 0.400};
 	defaultProf.enableConfidenceEllipsoid = true;
 	defaultProf.confLevel = 0.9;
 	defaultProf.gridSearch.autoLatLon = true;
@@ -309,11 +323,13 @@ bool StdLoc::init(const Config::Config &config) {
 	defaultProf.gridSearch.cellXExtent = 2.5;
 	defaultProf.gridSearch.cellYExtent = 2.5;
 	defaultProf.gridSearch.cellZExtent = 5.0;
-	defaultProf.gridSearch.errorType = "L1";
-	defaultProf.gridSearch.maxRms = -1;
-	defaultProf.leastSquare.iterations = 20;
-	defaultProf.leastSquare.dampingFactor = 0;
-	defaultProf.leastSquare.solverType = "LSMR";
+	defaultProf.gridSearch.misfitType = "L1";
+	defaultProf.gridSearch.travelTimeError = 0.25;
+	defaultProf.octTree.maxIterations = 50000;
+	defaultProf.octTree.minCellSize = 0.1;
+	defaultProf.leastSquares.iterations = 20;
+	defaultProf.leastSquares.dampingFactor = 0;
+	defaultProf.leastSquares.solverType = "LSMR";
 
 	_currentProfile = defaultProf;
 
@@ -333,8 +349,14 @@ bool StdLoc::init(const Config::Config &config) {
 			else if ( method == "GridSearch" ) {
 				prof.method = Profile::Method::GridSearch;
 			}
+			else if ( method == "OctTree" ) {
+				prof.method = Profile::Method::OctTree;
+			}
 			else if ( method == "GridSearch+LeastSquares" ) {
 				prof.method = Profile::Method::GridAndLsqr;
+			}
+			else if ( method == "OctTree+LeastSquares" ) {
+				prof.method = Profile::Method::OctTreeAndLsqr;
 			}
 			else {
 				SEISCOMP_ERROR("Profile %s: unrecognized method %s",
@@ -354,23 +376,28 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			prof.usePickUncertainties = config.getBool(prefix + "usePickUncertainties");
+			prof.usePickUncertainties =
+			    config.getBool(prefix + "usePickUncertainties");
 		}
 		catch ( ... ) {}
 
 		try {
-			vector<string> tokens = config.getStrings(prefix + "pickUncertaintyClasses");
+			vector<string> tokens =
+			    config.getStrings(prefix + "pickUncertaintyClasses");
 			if ( tokens.size() < 2 ) {
-				SEISCOMP_ERROR("Profile %s: pickUncertaintyClasses should contain at least "
-				               "2 values", prof.name.c_str());
+				SEISCOMP_ERROR("Profile %s: pickUncertaintyClasses should "
+				               "contain at least "
+				               "2 values",
+				               prof.name.c_str());
 				return false;
 			}
 			prof.pickUncertaintyClasses.clear();
-			for ( const string& tok : tokens ) {
+			for ( const string &tok : tokens ) {
 				double time;
 				if ( !Core::fromString(time, tok) ) {
-					SEISCOMP_ERROR("Profile %s: pickUncertaintyClasses is invalid",
-				                 prof.name.c_str());
+					SEISCOMP_ERROR(
+					    "Profile %s: pickUncertaintyClasses is invalid",
+					    prof.name.c_str());
 					return false;
 				}
 				prof.pickUncertaintyClasses.push_back(time);
@@ -379,7 +406,8 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			prof.enableConfidenceEllipsoid = config.getBool(prefix + "enableConfidenceEllipsoid");
+			prof.enableConfidenceEllipsoid =
+			    config.getBool(prefix + "enableConfidenceEllipsoid");
 		}
 		catch ( ... ) {}
 
@@ -389,14 +417,17 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			prof.gridSearch.autoLatLon = config.getBool(prefix + "GridSearch.autoLatLon");
+			prof.gridSearch.autoLatLon =
+			    config.getBool(prefix + "GridSearch.autoLatLon");
 		}
 		catch ( ... ) {}
 
 		try {
-			vector<string> tokens = config.getStrings(prefix + "GridSearch.center");
+			vector<string> tokens =
+			    config.getStrings(prefix + "GridSearch.center");
 			if ( tokens.size() != 3 ||
-			     !Core::fromString(prof.gridSearch.originDepth, tokens.at(2)) ) {
+			     !Core::fromString(prof.gridSearch.originDepth,
+			                       tokens.at(2)) ) {
 				SEISCOMP_ERROR("Profile %s: GridSearch.center is invalid",
 				               prof.name.c_str());
 				return false;
@@ -406,8 +437,10 @@ bool StdLoc::init(const Config::Config &config) {
 				prof.gridSearch.originLat = 0.0;
 				prof.gridSearch.originLon = 0.0;
 			}
-			else if ( !Core::fromString(prof.gridSearch.originLat, tokens.at(0)) ||
-			          !Core::fromString(prof.gridSearch.originLon, tokens.at(1)) ) {
+			else if ( !Core::fromString(prof.gridSearch.originLat,
+			                            tokens.at(0)) ||
+			          !Core::fromString(prof.gridSearch.originLon,
+			                            tokens.at(1)) ) {
 				SEISCOMP_ERROR("Profile %s: GridSearch.center is invalid",
 				               prof.name.c_str());
 				return false;
@@ -416,11 +449,12 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			vector<string> tokens = config.getStrings(prefix + "GridSearch.size");
-			if (tokens.size() != 3 ||
-			    !Core::fromString(prof.gridSearch.xExtent, tokens.at(0)) ||
-			    !Core::fromString(prof.gridSearch.yExtent, tokens.at(1)) ||
-			    !Core::fromString(prof.gridSearch.zExtent, tokens.at(2)) ) {
+			vector<string> tokens =
+			    config.getStrings(prefix + "GridSearch.size");
+			if ( tokens.size() != 3 ||
+			     !Core::fromString(prof.gridSearch.xExtent, tokens.at(0)) ||
+			     !Core::fromString(prof.gridSearch.yExtent, tokens.at(1)) ||
+			     !Core::fromString(prof.gridSearch.zExtent, tokens.at(2)) ) {
 				SEISCOMP_ERROR("Profile %s: GridSearch.size is invalid",
 				               prof.name.c_str());
 				return false;
@@ -429,11 +463,13 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			vector<string> tokens = config.getStrings(prefix + "GridSearch.cellSize");
+			vector<string> tokens =
+			    config.getStrings(prefix + "GridSearch.cellSize");
 			if ( tokens.size() != 3 ||
 			     !Core::fromString(prof.gridSearch.cellXExtent, tokens.at(0)) ||
 			     !Core::fromString(prof.gridSearch.cellYExtent, tokens.at(1)) ||
-			     !Core::fromString(prof.gridSearch.cellZExtent, tokens.at(2))) {
+			     !Core::fromString(prof.gridSearch.cellZExtent,
+			                       tokens.at(2)) ) {
 				SEISCOMP_ERROR("Profile %s: GridSearch.cellSize is invalid",
 				               prof.name.c_str());
 				return false;
@@ -442,10 +478,11 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			prof.gridSearch.errorType = config.getString(prefix + "GridSearch.errorType");
-			if ( prof.gridSearch.errorType != "L1" &&
-			     prof.gridSearch.errorType != "L2") {
-				SEISCOMP_ERROR("Profile %s: GridSearch.errorType is invalid",
+			prof.gridSearch.misfitType =
+			    config.getString(prefix + "GridSearch.misfitType");
+			if ( prof.gridSearch.misfitType != "L1" &&
+			     prof.gridSearch.misfitType != "L2" ) {
+				SEISCOMP_ERROR("Profile %s: GridSearch.misfitType is invalid",
 				               prof.name.c_str());
 				return false;
 			}
@@ -453,25 +490,41 @@ bool StdLoc::init(const Config::Config &config) {
 		catch ( ... ) {}
 
 		try {
-			prof.gridSearch.maxRms = config.getDouble(prefix + "GridSearch.maxRms");
+			prof.gridSearch.travelTimeError =
+			    config.getDouble(prefix + "GridSearch.travelTimeError");
 		}
 		catch ( ... ) {}
 
 		try {
-			prof.leastSquare.iterations = config.getInt(prefix + "LeastSquares.iterations");
+			prof.octTree.maxIterations =
+			    config.getInt(prefix + "OctTree.maxIterations");
 		}
 		catch ( ... ) {}
 
 		try {
-			prof.leastSquare.dampingFactor = config.getDouble(prefix + "LeastSquares.dampingFactor");
+			prof.octTree.minCellSize =
+			    config.getDouble(prefix + "OctTree.minCellSize");
 		}
 		catch ( ... ) {}
 
 		try {
-			prof.leastSquare.solverType = config.getString(prefix + "LeastSquares.solverType");
-			if ( prof.leastSquare.solverType != "LSMR" &&
-			     prof.leastSquare.solverType != "LSQR") {
-				SEISCOMP_ERROR("Profile %s: leastSquare.solverType is invalid",
+			prof.leastSquares.iterations =
+			    config.getInt(prefix + "LeastSquares.iterations");
+		}
+		catch ( ... ) {}
+
+		try {
+			prof.leastSquares.dampingFactor =
+			    config.getDouble(prefix + "LeastSquares.dampingFactor");
+		}
+		catch ( ... ) {}
+
+		try {
+			prof.leastSquares.solverType =
+			    config.getString(prefix + "LeastSquares.solverType");
+			if ( prof.leastSquares.solverType != "LSMR" &&
+			     prof.leastSquares.solverType != "LSQR" ) {
+				SEISCOMP_ERROR("Profile %s: leastSquares.solverType is invalid",
 				               prof.name.c_str());
 				return false;
 			}
@@ -491,11 +544,10 @@ bool StdLoc::init(const Config::Config &config) {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 IDList StdLoc::profiles() const {
 	IDList keys;
-	transform(
-		begin(_profiles), end(_profiles), back_inserter(keys),
-		[](decltype(_profiles)::value_type const &pair) {
-			return pair.first;
-	});
+	transform(begin(_profiles), end(_profiles), back_inserter(keys),
+	          [](decltype(_profiles)::value_type const &pair) {
+		          return pair.first;
+	          });
 	return keys;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -527,11 +579,17 @@ string StdLoc::parameter(const string &name) const {
 		if ( _currentProfile.method == Profile::Method::LeastSquares ) {
 			return "LeastSquares";
 		}
-		else if (_currentProfile.method == Profile::Method::GridSearch) {
+		else if ( _currentProfile.method == Profile::Method::GridSearch ) {
 			return "GridSearch";
 		}
-		else if (_currentProfile.method == Profile::Method::GridAndLsqr) {
+		else if ( _currentProfile.method == Profile::Method::OctTree ) {
+			return "OctTree";
+		}
+		else if ( _currentProfile.method == Profile::Method::GridAndLsqr ) {
 			return "GridSearch+LeastSquares";
+		}
+		else if ( _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+			return "OctTree+LeastSquares";
 		}
 	}
 	else if ( name == "tttType" ) {
@@ -548,7 +606,7 @@ string StdLoc::parameter(const string &name) const {
 	}
 	else if ( name == "pickUncertaintyClasses" ) {
 		string value;
-		for ( double time :_currentProfile.pickUncertaintyClasses ) {
+		for ( double time : _currentProfile.pickUncertaintyClasses ) {
 			if ( !value.empty() ) {
 				value += ",";
 			}
@@ -563,21 +621,21 @@ string StdLoc::parameter(const string &name) const {
 		return Core::toString(_currentProfile.confLevel);
 	}
 	else if ( name == "LeastSquares.iterations" ) {
-		return Core::toString(_currentProfile.leastSquare.iterations);
+		return Core::toString(_currentProfile.leastSquares.iterations);
 	}
 	else if ( name == "LeastSquares.dampingFactor" ) {
-		return Core::toString(_currentProfile.leastSquare.dampingFactor);
+		return Core::toString(_currentProfile.leastSquares.dampingFactor);
 	}
 	else if ( name == "LeastSquares.solverType" ) {
-		return _currentProfile.leastSquare.solverType;
+		return _currentProfile.leastSquares.solverType;
 	}
 	else if ( name == "GridSearch.autoLatLon" ) {
 		return _currentProfile.gridSearch.autoLatLon ? "y" : "n";
 	}
 	else if ( name == "GridSearch.center" ) {
 		if ( _currentProfile.gridSearch.autoLatLon ) {
-			return "lat,lon," +
-			        Core::toString(_currentProfile.gridSearch.originDepth);
+			return "auto,auto," +
+			       Core::toString(_currentProfile.gridSearch.originDepth);
 		}
 		else {
 			return Core::toString(_currentProfile.gridSearch.originLat) + "," +
@@ -595,11 +653,17 @@ string StdLoc::parameter(const string &name) const {
 		       Core::toString(_currentProfile.gridSearch.cellYExtent) + "," +
 		       Core::toString(_currentProfile.gridSearch.cellZExtent);
 	}
-	else if ( name == "GridSearch.errorType" ) {
-		return _currentProfile.gridSearch.errorType;
+	else if ( name == "GridSearch.misfitType" ) {
+		return _currentProfile.gridSearch.misfitType;
 	}
-	else if ( name == "GridSearch.maxRms" ) {
-		return Core::toString(_currentProfile.gridSearch.maxRms);
+	else if ( name == "GridSearch.travelTimeError" ) {
+		return Core::toString(_currentProfile.gridSearch.travelTimeError);
+	}
+	else if ( name == "OctTree.maxIterations" ) {
+		return Core::toString(_currentProfile.octTree.maxIterations);
+	}
+	else if ( name == "OctTree.minCellSize" ) {
+		return Core::toString(_currentProfile.octTree.minCellSize);
 	}
 
 	return "";
@@ -621,8 +685,16 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 			_currentProfile.method = Profile::Method::GridSearch;
 			return true;
 		}
+		else if ( value == "OctTree" ) {
+			_currentProfile.method = Profile::Method::OctTree;
+			return true;
+		}
 		else if ( value == "GridSearch+LeastSquares" ) {
 			_currentProfile.method = Profile::Method::GridAndLsqr;
+			return true;
+		}
+		else if ( value == "OctTree+LeastSquares" ) {
+			_currentProfile.method = Profile::Method::OctTreeAndLsqr;
 			return true;
 		}
 		else {
@@ -649,12 +721,14 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 	else if ( name == "pickUncertaintyClasses" ) {
 		vector<string> tokens = splitString(value);
 		if ( tokens.size() < 2 ) {
-			SEISCOMP_ERROR("Profile %s: pickUncertaintyClasses should contain at least "
-			               "2 values", _currentProfile.name.c_str());
+			SEISCOMP_ERROR(
+			    "Profile %s: pickUncertaintyClasses should contain at least "
+			    "2 values",
+			    _currentProfile.name.c_str());
 			return false;
 		}
 		_currentProfile.pickUncertaintyClasses.clear();
-		for ( const string& tok : tokens ) {
+		for ( const string &tok : tokens ) {
 			double time;
 			if ( !Core::fromString(time, tok) ) {
 				SEISCOMP_ERROR("Profile %s: pickUncertaintyClasses is invalid",
@@ -682,7 +756,7 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 		if ( !Core::fromString(tmp, value) ) {
 			return false;
 		}
-		_currentProfile.leastSquare.iterations = tmp;
+		_currentProfile.leastSquares.iterations = tmp;
 		return true;
 	}
 	else if ( name == "LeastSquares.dampingFactor" ) {
@@ -690,14 +764,14 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 		if ( !Core::fromString(tmp, value) ) {
 			return false;
 		}
-		_currentProfile.leastSquare.dampingFactor = tmp;
+		_currentProfile.leastSquares.dampingFactor = tmp;
 		return true;
 	}
 	else if ( name == "LeastSquares.solverType" ) {
 		if ( value != "LSMR" && value != "LSQR" ) {
 			return false;
 		}
-		_currentProfile.leastSquare.solverType = value;
+		_currentProfile.leastSquares.solverType = value;
 		return true;
 	}
 	else if ( name == "GridSearch.autoLatLon" ) {
@@ -708,7 +782,7 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 		vector<string> tokens = splitString(value);
 		if ( tokens.size() != 3 ||
 		     !Core::fromString(_currentProfile.gridSearch.originDepth,
-		                       tokens.at(2))) {
+		                       tokens.at(2)) ) {
 			SEISCOMP_ERROR("Profile %s: GridSearch.center is invalid",
 			               _currentProfile.name.c_str());
 			return false;
@@ -731,9 +805,12 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 	else if ( name == "GridSearch.size" ) {
 		vector<string> tokens = splitString(value);
 		if ( tokens.size() != 3 ||
-		     !Core::fromString(_currentProfile.gridSearch.xExtent, tokens.at(0)) ||
-		     !Core::fromString(_currentProfile.gridSearch.yExtent, tokens.at(1)) ||
-		     !Core::fromString(_currentProfile.gridSearch.zExtent, tokens.at(2)) ) {
+		     !Core::fromString(_currentProfile.gridSearch.xExtent,
+		                       tokens.at(0)) ||
+		     !Core::fromString(_currentProfile.gridSearch.yExtent,
+		                       tokens.at(1)) ||
+		     !Core::fromString(_currentProfile.gridSearch.zExtent,
+		                       tokens.at(2)) ) {
 			return false;
 		}
 		return true;
@@ -751,19 +828,33 @@ bool StdLoc::setParameter(const string &name, const string &value) {
 		}
 		return true;
 	}
-	else if ( name == "GridSearch.errorType" ) {
+	else if ( name == "GridSearch.misfitType" ) {
 		if ( value != "L1" && value != "L2" ) {
 			return false;
 		}
-		_currentProfile.gridSearch.errorType = value;
+		_currentProfile.gridSearch.misfitType = value;
 		return true;
 	}
-	else if ( name == "GridSearch.maxRms" ) {
+	else if ( name == "GridSearch.travelTimeError" ) {
 		double tmp;
 		if ( !Core::fromString(tmp, value) ) {
 			return false;
 		}
-		_currentProfile.gridSearch.maxRms = tmp;
+		_currentProfile.gridSearch.travelTimeError = tmp;
+	}
+	else if ( name == "OctTree.maxIterations" ) {
+		int tmp;
+		if ( !Core::fromString(tmp, value) ) {
+			return false;
+		}
+		_currentProfile.octTree.maxIterations = tmp;
+	}
+	else if ( name == "OctTree.minCellSize" ) {
+		double tmp;
+		if ( !Core::fromString(tmp, value) ) {
+			return false;
+		}
+		_currentProfile.octTree.minCellSize = tmp;
 	}
 
 	return false;
@@ -814,28 +905,52 @@ Origin *StdLoc::locate(PickList &pickList) {
 	SEISCOMP_DEBUG("Locating Origin using PickList with profile '%s'",
 	               _currentProfile.name.c_str());
 
-	if ( _currentProfile.method != Profile::Method::GridSearch &&
-	     _currentProfile.method != Profile::Method::GridAndLsqr ) {
-		throw LocatorException("Cannot locate without an initial location: add the GridSearch");
+	if ( _currentProfile.method == Profile::Method::LeastSquares ) {
+		throw LocatorException(
+		    "LeastSquares method requires an initial location");
 	}
 
 	loadTTT();
 
 	vector<double> weights, sensorLat, sensorLon, sensorElev;
-	computeAdditionlPickInfo(pickList, weights, sensorLat, sensorLon, sensorElev);
+	computeAdditionlPickInfo(pickList, weights, sensorLat, sensorLon,
+	                         sensorElev);
 
+	// these are the output of the location
 	double originLat, originLon, originDepth;
 	Core::Time originTime;
-	vector<double> travelTimes;
+	vector<double> residuals;
 	CovMtrx covm;
 
-	locateGridSearch(pickList, weights, sensorLat, sensorLon, sensorElev,
-	                 originLat, originLon, originDepth, originTime, travelTimes,
-	                 covm, _currentProfile.enableConfidenceEllipsoid);
+	bool computeCovMtrx = _currentProfile.enableConfidenceEllipsoid;
+
+	if ( _currentProfile.method == Profile::Method::GridSearch ||
+	     _currentProfile.method == Profile::Method::GridAndLsqr ) {
+		bool enablePerCellLeastSquares =
+		    _currentProfile.method == Profile::Method::GridAndLsqr;
+		locateGridSearch(pickList, weights, sensorLat, sensorLon, sensorElev,
+		                 originLat, originLon, originDepth, originTime,
+		                 residuals, covm, computeCovMtrx,
+		                 enablePerCellLeastSquares);
+	}
+	else if ( _currentProfile.method == Profile::Method::OctTree ||
+	          _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+		locateOctTree(pickList, weights, sensorLat, sensorLon, sensorElev,
+		              originLat, originLon, originDepth, originTime,
+		              residuals, covm,
+		              (computeCovMtrx &&
+		               _currentProfile.method == Profile::Method::OctTree));
+		if ( _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+			locateLeastSquares(pickList, weights, sensorLat, sensorLon,
+			                   sensorElev, originLat, originLon, originDepth,
+			                   originTime, originLat, originLon, originDepth,
+			                   originTime, residuals, covm, computeCovMtrx);
+		}
+	}
 
 	return createOrigin(pickList, weights, sensorLat, sensorLon, sensorElev,
 	                    originLat, originLon, originDepth, originTime,
-	                    travelTimes, covm);
+	                    residuals, covm);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -846,40 +961,58 @@ Origin *StdLoc::locate(PickList &pickList) {
 Origin *StdLoc::locate(PickList &pickList, double initLat, double initLon,
                        double initDepth, const Core::Time &initTime) {
 
-	if ( isInitialLocationIgnored() ) {
-		return locate(pickList);
-	}
-
 	loadTTT();
 
-	SEISCOMP_DEBUG("Locating Origin using PickList and an initial location using "
-	               "profile '%s'",
-	               _currentProfile.name.c_str());
+	SEISCOMP_DEBUG(
+	    "Locating Origin using PickList and an initial location using "
+	    "profile '%s'",
+	    _currentProfile.name.c_str());
 
 	vector<double> weights, sensorLat, sensorLon, sensorElev;
-	computeAdditionlPickInfo(pickList, weights, sensorLat, sensorLon, sensorElev);
+	computeAdditionlPickInfo(pickList, weights, sensorLat, sensorLon,
+	                         sensorElev);
 
+	// these are the output of the location
 	double originLat, originLon, originDepth;
 	Core::Time originTime;
-	vector<double> travelTimes;
+	vector<double> residuals;
 	CovMtrx covm;
+
+	bool computeCovMtrx = _currentProfile.enableConfidenceEllipsoid;
 
 	if ( _currentProfile.method == Profile::Method::GridSearch ||
 	     _currentProfile.method == Profile::Method::GridAndLsqr ) {
+		bool enablePerCellLeastSquares =
+		    _currentProfile.method == Profile::Method::GridAndLsqr;
 		locateGridSearch(pickList, weights, sensorLat, sensorLon, sensorElev,
-		                 originLat, originLon, originDepth, originTime, travelTimes,
-		                 covm, _currentProfile.enableConfidenceEllipsoid);
+		                 originLat, originLon, originDepth, originTime,
+		                 residuals, covm, computeCovMtrx,
+		                 enablePerCellLeastSquares);
 	}
-	else if (_currentProfile.method == Profile::Method::LeastSquares) {
+	else if ( _currentProfile.method == Profile::Method::OctTree ||
+	          _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+		locateOctTree(pickList, weights, sensorLat, sensorLon, sensorElev,
+		              originLat, originLon, originDepth, originTime,
+		              residuals, covm,
+		              (computeCovMtrx &&
+		               _currentProfile.method == Profile::Method::OctTree));
+		if ( _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+			locateLeastSquares(pickList, weights, sensorLat, sensorLon,
+			                   sensorElev, originLat, originLon, originDepth,
+			                   originTime, originLat, originLon, originDepth,
+			                   originTime, residuals, covm, computeCovMtrx);
+		}
+	}
+	else if ( _currentProfile.method == Profile::Method::LeastSquares ) {
 		locateLeastSquares(pickList, weights, sensorLat, sensorLon, sensorElev,
 		                   initLat, initLon, initDepth, initTime, originLat,
-		                   originLon, originDepth, originTime, travelTimes,
-		                   covm, _currentProfile.enableConfidenceEllipsoid);
+		                   originLon, originDepth, originTime, residuals, covm,
+		                   computeCovMtrx);
 	}
 
 	return createOrigin(pickList, weights, sensorLat, sensorLon, sensorElev,
 	                    originLat, originLon, originDepth, originTime,
-	                    travelTimes, covm);
+	                    residuals, covm);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -931,13 +1064,14 @@ Origin *StdLoc::relocate(const Origin *origin) {
 	for ( size_t i = 0; i < origin->arrivalCount(); ++i ) {
 		PickPtr pick = getPick(origin->arrival(i));
 		if ( !pick ) {
-			throw PickNotFoundException("pick '" + origin->arrival(i)->pickID() +
-			                            "' not found");
+			throw PickNotFoundException(
+			    "pick '" + origin->arrival(i)->pickID() + "' not found");
 		}
 
 		try {
 			// Phase definition of arrival and pick different?
-			if ( pick->phaseHint().code() != origin->arrival(i)->phase().code() ) {
+			if ( pick->phaseHint().code() !=
+			     origin->arrival(i)->phase().code() ) {
 				PickPtr np = new Pick(*pick);
 				np->setPhaseHint(origin->arrival(i)->phase());
 				pick = np;
@@ -980,9 +1114,9 @@ void StdLoc::computeAdditionlPickInfo(const PickList &pickList,
 		SensorLocation *sloc = getSensorLocation(pick.get());
 		if ( !sloc ) {
 			throw StationNotFoundException(
-			            "sensor location '" + pick->waveformID().networkCode() + "." +
-			            pick->waveformID().stationCode() + "." +
-			            pick->waveformID().locationCode() + "' not found");
+			    "sensor location '" + pick->waveformID().networkCode() + "." +
+			    pick->waveformID().stationCode() + "." +
+			    pick->waveformID().locationCode() + "' not found");
 		}
 
 		try {
@@ -991,11 +1125,11 @@ void StdLoc::computeAdditionlPickInfo(const PickList &pickList,
 			sensorElev[i] = sloc->elevation();
 		}
 		catch ( ... ) {
-			throw LocatorException(
-				"sensor location '" + pick->waveformID().networkCode() + "." +
-				pick->waveformID().stationCode() + "." +
-				pick->waveformID().locationCode() + "' is incomplete w.r.t. lat/lon"
-			);
+			throw LocatorException("sensor location '" +
+			                       pick->waveformID().networkCode() + "." +
+			                       pick->waveformID().stationCode() + "." +
+			                       pick->waveformID().locationCode() +
+			                       "' is incomplete w.r.t. lat/lon");
 		}
 
 		if ( pi.flags == LocatorInterface::F_NONE ) {
@@ -1010,8 +1144,9 @@ void StdLoc::computeAdditionlPickInfo(const PickList &pickList,
 
 		weights[i] = 1.0; // marks the pick as used
 
-		if (_currentProfile.usePickUncertainties) {
-			weights[i] = computePickWeight(pick.get(), _currentProfile.pickUncertaintyClasses);
+		if ( _currentProfile.usePickUncertainties ) {
+			weights[i] = computePickWeight(
+			    pick.get(), _currentProfile.pickUncertaintyClasses);
 		}
 		++activeArrivals;
 	}
@@ -1026,17 +1161,171 @@ void StdLoc::computeAdditionlPickInfo(const PickList &pickList,
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-void StdLoc::locateGridSearch(
-	const PickList &pickList, const vector<double> &weights,
-	const vector<double> &sensorLat, const vector<double> &sensorLon,
-	const vector<double> &sensorElev, double &newLat, double &newLon,
-	double &newDepth, Core::Time &newTime, vector<double> &travelTimes,
-	CovMtrx& covm, bool computeCovMtrx
-) const {
-	SEISCOMP_DEBUG("Start Grid Search");
+void StdLoc::computeProbDensity(const PickList &pickList,
+                                const vector<double> &weights,
+                                const vector<double> &travelTimes,
+                                const Core::Time &originTime,
+                                double &probDensity, double &rms,
+                                vector<double> &residuals) const {
+
+	if ( _currentProfile.gridSearch.misfitType != "L1" &&
+	     _currentProfile.gridSearch.misfitType != "L2" ) {
+		throw LocatorException("The error type can only be L1 or "
+		                       "L2, but it is set to " +
+		                       _currentProfile.gridSearch.misfitType);
+	}
+
+	if ( weights.size() != pickList.size() ||
+	     travelTimes.size() != pickList.size() ) {
+		throw LocatorException("Interna logic error");
+	}
+
+	residuals.resize(pickList.size());
+	rms = 0.0;
+
+	double l1SumWeightedResiduals = 0.0;
+	double l2SumWeightedResiduals = 0.0;
+	double sumSquaredWeights = 0.0;
+
+	for ( size_t i = 0; i < pickList.size(); ++i ) {
+		const PickItem &pi = pickList[i];
+		const PickPtr pick = pi.pick;
+
+		if ( weights[i] <= 0 ) {
+			residuals[i] = 0.;
+			continue;
+		}
+
+		Core::Time pickTime = pick->time().value();
+		double residual =
+		    (pickTime - (originTime + Core::TimeSpan(travelTimes[i]))).length();
+		residuals[i] = residual;
+		l1SumWeightedResiduals += abs(residual * weights[i]);
+		l2SumWeightedResiduals +=
+		    (residual * weights[i]) * (residual * weights[i]);
+		sumSquaredWeights += weights[i] * weights[i];
+	}
+
+	rms = sqrt(l2SumWeightedResiduals / sumSquaredWeights);
+
+	double sigma = _currentProfile.gridSearch.travelTimeError;
+	if ( _currentProfile.gridSearch.misfitType == "L1" ) {
+		probDensity = std::exp(-1.0 * l1SumWeightedResiduals / sigma);
+	}
+	else if ( _currentProfile.gridSearch.misfitType == "L2" ) {
+		probDensity = std::exp(-0.5 * l2SumWeightedResiduals / (sigma * sigma));
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool StdLoc::computeOriginTime(const PickList &pickList,
+                               const vector<double> &weights,
+                               const vector<double> &sensorLat,
+                               const vector<double> &sensorLon,
+                               const vector<double> &sensorElev, double lat,
+                               double lon, double depth, Core::Time &originTime,
+                               vector<double> &travelTimes) const {
+
+	if ( weights.size() != pickList.size() ||
+	     sensorLat.size() != pickList.size() ||
+	     sensorLon.size() != pickList.size() ||
+	     sensorElev.size() != pickList.size() ) {
+		throw LocatorException("Interna logic error");
+	}
+
+	travelTimes.resize(pickList.size());
+
+	vector<double> originTimes;
+	vector<double> timeWeights;
+
+	for ( size_t i = 0; i < pickList.size(); ++i ) {
+		const PickItem &pi = pickList[i];
+		const PickPtr pick = pi.pick;
+
+		if ( weights[i] <= 0 ) {
+			travelTimes[i] = 0;
+			continue;
+		}
+
+		TravelTime tt;
+
+		try {
+			const char *phaseName = pick->phaseHint().code().c_str();
+			if ( _currentProfile.PSTableOnly ) {
+				if ( *pick->phaseHint().code().begin() == 'P' ) {
+					phaseName = "P";
+				}
+				else if ( *pick->phaseHint().code().begin() == 'S' ) {
+					phaseName = "S";
+				}
+			}
+			tt = _ttt->compute(phaseName, lat, lon, depth, sensorLat[i],
+			                   sensorLon[i], sensorElev[i]);
+		}
+		catch ( exception &e ) {
+			SEISCOMP_WARNING("Travel Time Table error for %s@%s.%s.%s and lat "
+			                 "%g lon %g depth %g: %s",
+			                 pick->phaseHint().code().c_str(),
+			                 pick->waveformID().networkCode().c_str(),
+			                 pick->waveformID().stationCode().c_str(),
+			                 pick->waveformID().locationCode().c_str(), lat,
+			                 lon, depth, e.what());
+			return false;
+		}
+
+		if ( tt.time < 0 ) {
+			SEISCOMP_WARNING("Travel Time Table error: data not returned for "
+			                 "%s@%s.%s.%s and lat %g lon %g depth %g",
+			                 pick->phaseHint().code().c_str(),
+			                 pick->waveformID().networkCode().c_str(),
+			                 pick->waveformID().stationCode().c_str(),
+			                 pick->waveformID().locationCode().c_str(), lat,
+			                 lon, depth);
+			return false;
+		}
+
+		travelTimes[i] = tt.time;
+		double pickTime = double(pick->time().value());
+		originTimes.push_back(pickTime - travelTimes[i]);
+		timeWeights.push_back(weights[i]);
+	}
+
+	if ( originTimes.size() == 0 ) {
+		return false;
+	}
+
+	// Compute origin time
+	double orgTime, orgTimeError;
+	Math::Statistics::average(originTimes, timeWeights, orgTime, orgTimeError);
+	originTime = Core::Time(orgTime);
+
+	return true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void StdLoc::locateOctTree(const PickList &pickList,
+                           const vector<double> &weights,
+                           const vector<double> &sensorLat,
+                           const vector<double> &sensorLon,
+                           const vector<double> &sensorElev, double &newLat,
+                           double &newLon, double &newDepth,
+                           Core::Time &newTime, vector<double> &residuals,
+                           CovMtrx &covm, bool computeCovMtrx) const {
+	SEISCOMP_DEBUG("Start OctTree Search: maxIterations %d minCellSize %g [km]",
+	               _currentProfile.octTree.maxIterations,
+	               _currentProfile.octTree.minCellSize);
 
 	if ( !_ttt ) {
-		throw LocatorException("Travel time table has not been loaded, check logs");
+		throw LocatorException(
+		    "Travel time table has not been loaded, check logs");
 	}
 
 	if ( pickList.empty() ) {
@@ -1046,277 +1335,311 @@ void StdLoc::locateGridSearch(
 	if ( weights.size() != pickList.size() ||
 	     sensorLat.size() != pickList.size() ||
 	     sensorLon.size() != pickList.size() ||
-	     sensorElev.size() != pickList.size()) {
+	     sensorElev.size() != pickList.size() ) {
 		throw LocatorException("Interna logic error");
+	}
+
+	if ( _currentProfile.octTree.maxIterations <= 0 &&
+	     _currentProfile.octTree.minCellSize <= 0 ) {
+		throw LocatorException(
+		    "Either octTree.maxIterations or octTree.minCellSize must be used");
 	}
 
 	covm.valid = false;
 
-	travelTimes.resize(pickList.size());
-
+	double xExtent = _currentProfile.gridSearch.xExtent;
+	double yExtent = _currentProfile.gridSearch.yExtent;
+	double zExtent = _currentProfile.gridSearch.zExtent;
+	double cellXExtent = _currentProfile.gridSearch.cellXExtent;
+	double cellYExtent = _currentProfile.gridSearch.cellYExtent;
+	double cellZExtent = _currentProfile.gridSearch.cellZExtent;
 	double gridOriginLat = _currentProfile.gridSearch.originLat;
 	double gridOriginLon = _currentProfile.gridSearch.originLon;
-	if (_currentProfile.gridSearch.autoLatLon) {
+	double gridOriginDepth = _currentProfile.gridSearch.originDepth;
+
+	// Auto-position the grid center
+	if ( _currentProfile.gridSearch.autoLatLon ) {
 		gridOriginLat = computeMean(sensorLat);
-		gridOriginLon = Geo::GeoCoordinate::normalizeLon(computeCircularMean(sensorLon, false));
-		SEISCOMP_DEBUG("GridSearch.center latitude %f longitude %f", gridOriginLat,
-		               gridOriginLon);
+		gridOriginLon = Geo::GeoCoordinate::normalizeLon(
+		    computeCircularMean(sensorLon, false));
+		SEISCOMP_DEBUG("GridSearch.center latitude %f longitude %f",
+		               gridOriginLat, gridOriginLon);
 	}
 
-	// 
-	// Build the list of cells withing the grid
-	// 
-	vector<Cell> cells;
-	for (double x = -_currentProfile.gridSearch.xExtent / 2. +
-	           _currentProfile.gridSearch.cellXExtent / 2.;
-	      x < _currentProfile.gridSearch.xExtent / 2.;
-	      x += _currentProfile.gridSearch.cellXExtent ) {
-		for (double y = -_currentProfile.gridSearch.yExtent / 2. +
-		           _currentProfile.gridSearch.cellYExtent / 2;
-		      y < _currentProfile.gridSearch.yExtent / 2.;
-		      y += _currentProfile.gridSearch.cellYExtent ) {
-			for (double z = -_currentProfile.gridSearch.zExtent / 2. +
-			           _currentProfile.gridSearch.cellZExtent / 2;
-			      z < _currentProfile.gridSearch.zExtent / 2.;
-			      z += _currentProfile.gridSearch.cellZExtent ) {
+	// fix depth
+	if ( usingFixedDepth() ) {
+		gridOriginDepth = fixedDepth();
+		cellZExtent = cellXExtent < cellYExtent ? cellXExtent : cellYExtent;
+		zExtent = cellZExtent;
+	}
 
+	vector<Cell> unknownPriorityList;
+
+	//
+	// Start off with the initial grid cells
+	//
+	for ( double x = -xExtent / 2. + cellXExtent / 2.;
+	             x < xExtent / 2.;
+	             x += cellXExtent ) {
+		for ( double y = -yExtent / 2. + cellYExtent / 2;
+		             y < yExtent / 2.;
+		             y += cellYExtent ) {
+			for ( double z = -zExtent / 2. + cellZExtent / 2;
+			             z < zExtent / 2.;
+			             z += cellZExtent ) {
 				Cell cell;
 				cell.valid = false;
 				cell.x = x;
 				cell.y = y;
 				cell.z = z;
-				cell.org.depth = _currentProfile.gridSearch.originDepth + z;
-
-				// compute distance and azimuth of the cell centroid to the grid origin
-				double distance = sqrt(y * y + x * x); // km
-				double azimuth = rad2deg(atan2(x, y));
-
-				// Computes the coordinates (lat, lon) of the point which is at a degree
-				// azimuth and km distance as seen from the other point location
-				computeCoordinates(distance, azimuth,
-				                   gridOriginLat, gridOriginLon,
-				                   cell.org.lat, cell.org.lon);
-
-				cells.push_back(cell);
+				cell.size.x = cellXExtent;
+				cell.size.y = cellYExtent;
+				cell.size.z = cellZExtent;
+				unknownPriorityList.push_back(cell);
 			}
 		}
 	}
 
+	multimap<double, Cell> priorityList;
+	vector<double> cellTravelTimes(pickList.size());
+	vector<double> cellResiduals(pickList.size());
+	int processedCells = 0;
+	struct {
+			Cell cell;
+			double prob;
+	} best;
+	best.cell.valid = false;
+
 	//
-	// Process each cell now
+	// Process each cell by its priority
 	//
-	vector<double> originTimes;
-	vector<double> timeWeights;
-	Cell bestCell;
-	bestCell.valid = false;
-	vector<double> bestTravelTimes;
-	CovMtrx bestCovM;
+	while ( !priorityList.empty() || !unknownPriorityList.empty() ) {
 
-	for ( Cell& cell : cells ) {
+		// before fetching the next cell with the highest priority make
+		// sure to have processed all the cells in the unknownPriorityList
+		// and put them in the priority list
+		for ( Cell &cell : unknownPriorityList ) {
 
-		SEISCOMP_DEBUG("Processing cell x %g y %g z %g -> lon %g lat %g depth %g",
-		               cell.x, cell.y, cell.z,
-		               cell.org.lon, cell.org.lat, cell.org.depth);
+			processedCells++;
 
-		originTimes.clear();
-		timeWeights.clear();
+			cell.org.depth = gridOriginDepth + cell.z;
 
-		bool tttError = false;
-		for ( size_t i = 0; i < pickList.size(); ++i ) {
-			const PickItem &pi = pickList[i];
-			const PickPtr pick = pi.pick;
+			// compute distance and azimuth of the cell centroid to the grid
+			// origin
+			double distance = sqrt(cell.y * cell.y + cell.x * cell.x); // km
+			double azimuth = rad2deg(atan2(cell.x, cell.y));
 
-			if ( weights[i] <= 0 ) {
+			// Computes the coordinates (lat, lon) of the point which is at
+			// a degree azimuth and km distance as seen from the other point
+			// location
+			computeCoordinates(distance, azimuth, gridOriginLat, gridOriginLon,
+			                   cell.org.lat, cell.org.lon);
+
+			SEISCOMP_DEBUG(
+			    "Processing cell x %g y %g z %g -> lon %g lat %g depth %g",
+			    cell.x, cell.y, cell.z, cell.org.lon, cell.org.lat,
+			    cell.org.depth);
+
+			// Compute origin time
+			bool ok = computeOriginTime(pickList, weights, sensorLat, sensorLon,
+			                            sensorElev, cell.org.lat, cell.org.lon,
+			                            cell.org.depth, cell.org.time,
+			                            cellTravelTimes);
+
+			if ( !ok ) {
+				SEISCOMP_DEBUG("Skip cell: unable to compute origin time");
 				continue;
 			}
 
-			TravelTime tt;
+			// Compute the probability density
+			computeProbDensity(pickList, weights, cellTravelTimes,
+			                   cell.org.time, cell.org.probDensity,
+			                   cell.org.rms, cellResiduals);
 
-			try {
-				const char * phaseName = pick->phaseHint().code().c_str();
-				if ( _currentProfile.PSTableOnly ) {
-					if (*pick->phaseHint().code().begin() == 'P') {
-						phaseName = "P";
-					}
-					else if (*pick->phaseHint().code().begin() == 'S') {
-						phaseName = "S";
+			cell.valid = true;
+
+			// add cell to the priority list
+			double volume = cell.size.x * cell.size.y * cell.size.z;
+			double prob = volume * cell.org.probDensity; // unnormalized
+
+			SEISCOMP_DEBUG("Prob %g RMS %g (prob density %g volume %g)", prob,
+			               cell.org.rms, cell.org.probDensity, volume);
+
+			priorityList.emplace(prob, cell);
+		}
+		// all done
+		unknownPriorityList.clear();
+
+		//
+		// Fetch and split next 8 cells with the highest priority
+		// In theory we could just fetch the next cell, but with
+		// 8 the search is more thorough.
+		// In NonLinLoc the search if done on the highest priority
+		// cell plus its 6 direct neighbours (the 6 faces of the
+		// cell cube)
+		//
+		bool completed = false;
+		for ( int i = 0; i < 8; i++ ) {
+
+			if ( priorityList.empty() || completed ) {
+				break;
+			}
+
+			// Fetch next cell with the highest priority
+			double topCellProb = priorityList.crbegin()->first;
+			const Cell &topCell = priorityList.crbegin()->second;
+
+			SEISCOMP_DEBUG("Processed %d cells. Current cell size %g %g %g"
+			               " x %g y %g z %g prob %g RMS %f prob density %g",
+			               processedCells, topCell.size.x, topCell.size.y,
+			               topCell.size.z, topCell.x, topCell.y, topCell.z,
+			               topCellProb, topCell.org.rms,
+			               topCell.org.probDensity);
+
+			//
+			// Keep track of the best solution
+			//
+			if ( !best.cell.valid ||
+			     best.cell.org.probDensity < topCell.org.probDensity ) {
+				best.cell = topCell;
+				best.prob = topCellProb;
+				SEISCOMP_DEBUG("Preferring this as best cell");
+			}
+
+			//
+			// Check for completion
+			//
+			if ( _currentProfile.octTree.maxIterations > 0 &&
+			     processedCells >= _currentProfile.octTree.maxIterations ) {
+				SEISCOMP_DEBUG("Maximum number of iteration reached %d",
+				               processedCells);
+				completed = true;
+				break;
+			}
+
+			if ( _currentProfile.octTree.minCellSize > 0 &&
+			     (topCell.size.x <= _currentProfile.octTree.minCellSize ||
+			      topCell.size.y <= _currentProfile.octTree.minCellSize ||
+			      topCell.size.z <= _currentProfile.octTree.minCellSize) ) {
+				SEISCOMP_DEBUG("Minimum cell size reached: x %g y %g z %g [km]",
+				               topCell.size.x, topCell.size.y, topCell.size.z);
+				completed = true;
+				break;
+			}
+
+			//
+			// Split cell in 8 and add them to the unknownPriorityList
+			//
+			auto newCellToProcess = [&unknownPriorityList,
+			                         &topCell](double x, double y, double z) {
+				Cell cell;
+				cell.valid = false;
+				cell.x = topCell.x + x;
+				cell.y = topCell.y + y;
+				cell.z = topCell.z + z;
+				cell.size.x = topCell.size.x / 2.;
+				cell.size.y = topCell.size.y / 2.;
+				cell.size.z = topCell.size.z / 2.;
+				unknownPriorityList.push_back(cell);
+			};
+			for ( double x = -topCell.size.x / 4.;
+			             x <= topCell.size.x / 4.;
+			             x += topCell.size.x / 2. ) {
+				for ( double y = -topCell.size.y / 4.;
+				             y <= topCell.size.y / 4.;
+				             y += topCell.size.y / 2. ) {
+					if ( usingFixedDepth() ) {
+							newCellToProcess(x, y, 0);
+					} else {
+						for ( double z = -topCell.size.z / 4.;
+						             z <= topCell.size.z / 4.;
+						             z += topCell.size.z / 2. ) {
+							newCellToProcess(x, y, z);
+						}
 					}
 				}
-				tt = _ttt->compute(phaseName, cell.org.lat, cell.org.lon, cell.org.depth,
-													 sensorLat[i], sensorLon[i], sensorElev[i]);
-			}
-			catch ( exception &e ) {
-				SEISCOMP_WARNING("Travel Time Table error for %s@%s.%s.%s and lat "
-												 "%.6f lon %.6f depth %.3f: %s",
-												 pick->phaseHint().code().c_str(),
-												 pick->waveformID().networkCode().c_str(),
-												 pick->waveformID().stationCode().c_str(),
-												 pick->waveformID().locationCode().c_str(),
-												 cell.org.lat, cell.org.lon, cell.org.depth, e.what());
-				tttError = true;
-				break;
 			}
 
-			if ( tt.time < 0 ) {
-				SEISCOMP_WARNING("Travel Time Table error: data not returned for "
-												 "%s@%s.%s.%s and lat %.6f lon %.6f depth %.3f",
-												 pick->phaseHint().code().c_str(),
-												 pick->waveformID().networkCode().c_str(),
-												 pick->waveformID().stationCode().c_str(),
-												 pick->waveformID().locationCode().c_str(),
-												 cell.org.lat, cell.org.lon, cell.org.depth);
-				tttError = true;
-				break;
-			}
-
-			travelTimes[i] = tt.time;
-			double pickTime = double(pick->time().value());
-			originTimes.push_back(pickTime - travelTimes[i]);
-			timeWeights.push_back(weights[i]);
+			// Remove the current cell from priorityList since its
+			// children will be added at the next loop
+			priorityList.erase(std::prev(priorityList.end()));
 		}
 
-		if ( tttError ) {
-			SEISCOMP_DEBUG("Could not compute travel times of active arrivals: "
-										 "skip cell");
-			continue;
-		}
-
-		// Compute origin time for the Cell
-		double originTime, originTimeError;
-		Math::Statistics::average(originTimes, timeWeights, originTime,
-		                          originTimeError);
-		cell.org.time = Core::Time(originTime);
-
-		//
-		// Optionally run Least Squares from cell center
-		//
-		if ( _currentProfile.method == Profile::Method::GridAndLsqr ) {
-			try {
-				// note: cell data will be updated
-				locateLeastSquares(pickList, weights, sensorLat, sensorLon, sensorElev, 
-				                   cell.org.lat, cell.org.lon, cell.org.depth, cell.org.time,
-				                   cell.org.lat, cell.org.lon, cell.org.depth, cell.org.time,
-				                   travelTimes, covm, computeCovMtrx);
-			}
-			catch ( exception &e ) {
-				SEISCOMP_DEBUG(
-					"Could not get a Least Square solution (%s): skip cell",
-					e.what()
-				);
-				continue;
-			}
-		}
-
-		//
-		// Compute error for this location
-		//
-		double l1SumWeightedResiduals = 0.0;
-		double l2SumWeightedResiduals = 0.0;
-		double rms = 0.0;
-		int numResiduals = 0;
-
-		for ( size_t i = 0; i < pickList.size(); ++i ) {
-			const PickItem &pi = pickList[i];
-			const PickPtr pick = pi.pick;
-
-			if ( weights[i] <= 0 ) {
-				continue;
-			}
-
-			Core::Time pickTime = pick->time().value();
-			double residual =
-				(pickTime - (cell.org.time + Core::TimeSpan(travelTimes[i]))).length();
-			l1SumWeightedResiduals += abs(residual * weights[i]);
-			l2SumWeightedResiduals += (residual * weights[i]) * (residual * weights[i]);
-			rms = residual * residual;
-			numResiduals++;
-		}
-
-		rms = sqrt(rms) / numResiduals;
-
-		if ( _currentProfile.gridSearch.maxRms > 0 &&
-				 rms > _currentProfile.gridSearch.maxRms ) {
-			SEISCOMP_DEBUG(
-				"Unweighted rms %f is above GridSearch.maxRms %f -> reject cell",
-				rms, _currentProfile.gridSearch.maxRms
-			);
-			continue;
-		}
-
-		if ( _currentProfile.gridSearch.errorType == "L1" ) {
-			cell.org.error = l1SumWeightedResiduals;
-		}
-		else if ( _currentProfile.gridSearch.errorType == "L2" ) {
-			cell.org.error = l2SumWeightedResiduals;
-		}
-		else {
-			throw LocatorException("The GridSearch error type can only be L1 or "
-														 "L2, but it is set to" +
-														 _currentProfile.gridSearch.errorType);
-		}
-
-		cell.valid = true;
-
-		SEISCOMP_DEBUG("%s error %g unweighted rms %f",
-									 _currentProfile.gridSearch.errorType.c_str(),
-									 cell.org.error, rms);
-
-		if ( !bestCell.valid || bestCell.org.error > cell.org.error ) {
-			bestCell = cell;
-			bestTravelTimes = travelTimes;
-			bestCovM = covm;
-			SEISCOMP_DEBUG("Preferring this cell with error %g", bestCell.org.error);
+		if ( completed ) {
+			break;
 		}
 	}
+
+	if ( priorityList.empty() ) {
+		throw LocatorException("Couldn't find a solution");
+	}
+
+	double bestCellProb = best.prob;
+	const Cell &bestCell = best.cell;
 
 	if ( !bestCell.valid ) {
 		throw LocatorException("Couldn't find a solution");
 	}
 
-	// return the travel times for the solution
-	travelTimes = bestTravelTimes;
-
-	// compute covariance matrix if that is not already computed by LeastSquares
-	if ( computeCovMtrx && 
-      _currentProfile.method != Profile::Method::GridAndLsqr) {
-		computeCovarianceMatrix(cells, bestCell, covm);
-	} else {
-		covm = bestCovM;
-	}
+	SEISCOMP_DEBUG("Solution: cell size %g %g %g x %g y %g z %g prob %g "
+	               "RMS %f prob density %g",
+	               bestCell.size.x, bestCell.size.y, bestCell.size.z,
+	               bestCell.x, bestCell.y, bestCell.z, bestCellProb,
+	               bestCell.org.rms, bestCell.org.probDensity);
 
 	newLat = bestCell.org.lat;
 	newLon = bestCell.org.lon;
 	newDepth = bestCell.org.depth;
 	newTime = bestCell.org.time;
 
-	SEISCOMP_DEBUG(
-		"Grid Search lowest %s error %g at lon %g lat %g depth %g time %s",
-		_currentProfile.gridSearch.errorType.c_str(), bestCell.org.error,
-		newLon, newLat, newDepth, newTime.iso().c_str()
-	);
+	//
+	// To return the residuals we need to recompute them again (ugly)
+	//
+	Core::Time dummy1;
+	double dummy2;
+	if ( !computeOriginTime(pickList, weights, sensorLat, sensorLon, sensorElev,
+	                        newLat, newLon, newDepth, dummy1,
+	                        cellTravelTimes) ) {
+		throw LocatorException("Couldn't find a solution");
+	}
+	computeProbDensity(pickList, weights, cellTravelTimes, newTime, dummy2,
+	                   dummy2, residuals);
+
+	// compute covariance matrix
+	if ( computeCovMtrx ) {
+		// convert priorityList: map<double,Cell> -> vector<Cell>
+		vector<Cell> cells;
+		std::transform(begin(priorityList), end(priorityList),
+		               back_inserter(cells),
+		               [](decltype(priorityList)::value_type const &pair) {
+			               return pair.second;
+		               });
+		computeCovarianceMatrix(cells, bestCell, false, covm);
+	}
+	SEISCOMP_DEBUG("OctTree solution RMS %g lat %g lon %g depth %g time %s "
+	               "(num iterations %d)",
+	               bestCell.org.rms, newLat, newLon, newDepth,
+	               newTime.iso().c_str(), processedCells);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 
 
-
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-void StdLoc::locateLeastSquares(
-	const PickList &pickList, const vector<double> &weights,
-	const vector<double> &sensorLat, const vector<double> &sensorLon,
-	const vector<double> &sensorElev, double initLat, double initLon,
-	double initDepth, Core::Time initTime, double &newLat, double &newLon,
-	double &newDepth, Core::Time &newTime, vector<double> &travelTimes,
-	CovMtrx& covm, bool computeCovMtrx
-) const {
-
-	SEISCOMP_DEBUG(
-		"Start Least Square with initial lat %.6f lon %.6f depth %.3f time %s",
-		initLat, initLon, initDepth, initTime.iso().c_str()
-	);
+void StdLoc::locateGridSearch(const PickList &pickList,
+                              const vector<double> &weights,
+                              const vector<double> &sensorLat,
+                              const vector<double> &sensorLon,
+                              const vector<double> &sensorElev, double &newLat,
+                              double &newLon, double &newDepth,
+                              Core::Time &newTime, vector<double> &residuals,
+                              CovMtrx &covm, bool computeCovMtrx,
+                              bool enablePerCellLeastSquares) const {
+	SEISCOMP_DEBUG("Start Grid Search");
 
 	if ( !_ttt ) {
-		throw LocatorException("Travel time table has not been loaded, check logs");
+		throw LocatorException(
+		    "Travel time table has not been loaded, check logs");
 	}
 
 	if ( pickList.empty() ) {
@@ -1332,17 +1655,224 @@ void StdLoc::locateLeastSquares(
 
 	covm.valid = false;
 
-	travelTimes.resize(pickList.size());
+	double xExtent = _currentProfile.gridSearch.xExtent;
+	double yExtent = _currentProfile.gridSearch.yExtent;
+	double zExtent = _currentProfile.gridSearch.zExtent;
+	double cellXExtent = _currentProfile.gridSearch.cellXExtent;
+	double cellYExtent = _currentProfile.gridSearch.cellYExtent;
+	double cellZExtent = _currentProfile.gridSearch.cellZExtent;
+	double gridOriginLat = _currentProfile.gridSearch.originLat;
+	double gridOriginLon = _currentProfile.gridSearch.originLon;
+	double gridOriginDepth = _currentProfile.gridSearch.originDepth;
 
+	// Auto-position the grid center
+	if ( _currentProfile.gridSearch.autoLatLon ) {
+		gridOriginLat = computeMean(sensorLat);
+		gridOriginLon = Geo::GeoCoordinate::normalizeLon(
+		    computeCircularMean(sensorLon, false));
+		SEISCOMP_DEBUG("GridSearch.center latitude %f longitude %f",
+		               gridOriginLat, gridOriginLon);
+	}
+
+	// fix depth
+	if ( usingFixedDepth() ) {
+		gridOriginDepth = fixedDepth();
+		cellZExtent = cellXExtent < cellYExtent ? cellXExtent : cellYExtent;
+		zExtent = cellZExtent;
+	}
+
+	vector<Cell> cells;
+
+	//
+	// Build the list of cells withing the grid
+	//
+	for ( double x = -xExtent / 2. + cellXExtent / 2.;
+	             x < xExtent / 2.;
+	             x += cellXExtent ) {
+		for ( double y = -yExtent / 2. + cellYExtent / 2;
+		             y < yExtent / 2.;
+		             y += cellYExtent ) {
+			for ( double z = -zExtent / 2. + cellZExtent / 2;
+			             z < zExtent / 2.;
+			             z += cellZExtent ) { 
+				Cell cell;
+				cell.valid = false;
+				cell.x = x;
+				cell.y = y;
+				cell.z = z;
+				cell.size.x = cellXExtent;
+				cell.size.y = cellYExtent;
+				cell.size.z = cellZExtent;
+
+				cell.org.depth = gridOriginDepth + z;
+
+				// compute distance and azimuth of the cell centroid to the grid
+				// origin
+				double distance = sqrt(y * y + x * x); // km
+				double azimuth = rad2deg(atan2(x, y));
+
+				// Computes the coordinates (lat, lon) of the point which is at
+				// a degree azimuth and km distance as seen from the other point
+				// location
+				computeCoordinates(distance, azimuth, gridOriginLat,
+				                   gridOriginLon, cell.org.lat, cell.org.lon);
+
+				cells.push_back(cell);
+			}
+		}
+	}
+
+	vector<double> cellTravelTimes(pickList.size());
+	vector<double> cellResiduals(pickList.size());
+	struct {
+			Cell cell;
+			vector<double> residuals;
+			CovMtrx covm;
+	} best;
+	best.cell.valid = false;
+
+	//
+	// Process each cell now
+	//
+	for ( Cell &cell : cells ) {
+
+		SEISCOMP_DEBUG(
+		    "Processing cell x %g y %g z %g -> lon %g lat %g depth %g", cell.x,
+		    cell.y, cell.z, cell.org.lon, cell.org.lat, cell.org.depth);
+		//
+		// Compute origin time
+		//
+		bool ok = computeOriginTime(
+		    pickList, weights, sensorLat, sensorLon, sensorElev, cell.org.lat,
+		    cell.org.lon, cell.org.depth, cell.org.time, cellTravelTimes);
+
+		if ( !ok ) {
+			SEISCOMP_DEBUG("Skip cell: unable to compute origin time");
+			continue;
+		}
+
+		//
+		// Optionally run Least Squares from cell center:
+		// note that the cell position will be updated
+		//
+		if ( enablePerCellLeastSquares ) {
+			try {
+				locateLeastSquares(pickList, weights, sensorLat, sensorLon,
+				                   sensorElev, cell.org.lat, cell.org.lon,
+				                   cell.org.depth, cell.org.time, cell.org.lat,
+				                   cell.org.lon, cell.org.depth, cell.org.time,
+				                   residuals, covm, computeCovMtrx);
+			}
+			catch ( exception &e ) {
+				SEISCOMP_DEBUG(
+				    "Could not get a Least Square solution (%s): skip cell",
+				    e.what());
+				continue;
+			}
+		}
+
+		//
+		// Compute cell probability density
+		//
+		computeProbDensity(pickList, weights, cellTravelTimes, cell.org.time,
+		                   cell.org.probDensity, cell.org.rms, cellResiduals);
+
+		cell.valid = true;
+
+		SEISCOMP_DEBUG("Prob density %g RMS %g", cell.org.probDensity,
+		               cell.org.rms);
+
+		//
+		// Keep track of the best solution
+		//
+		if ( !best.cell.valid ||
+		     best.cell.org.probDensity < cell.org.probDensity ) {
+			best.cell = cell;
+			best.residuals = cellResiduals;
+			best.covm = covm;
+			SEISCOMP_DEBUG("Preferring this as best cell");
+		}
+	}
+
+	if ( !best.cell.valid ) {
+		throw LocatorException("Couldn't find a solution");
+	}
+
+	newLat = best.cell.org.lat;
+	newLon = best.cell.org.lon;
+	newDepth = best.cell.org.depth;
+	newTime = best.cell.org.time;
+
+	// return the travel times for the solution
+	residuals = best.residuals;
+
+	// compute covariance matrix if that is not already computed by LeastSquares
+	if ( computeCovMtrx && !enablePerCellLeastSquares ) {
+		computeCovarianceMatrix(cells, best.cell, false, covm);
+	}
+	else {
+		covm = best.covm;
+	}
+
+	SEISCOMP_DEBUG("Grid Search solution prob density %g RMS %g "
+	               "lat %g lon %g depth %g time %s",
+	               best.cell.org.probDensity, best.cell.org.rms, newLat, newLon,
+	               newDepth, newTime.iso().c_str());
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void StdLoc::locateLeastSquares(
+    const PickList &pickList, const vector<double> &weights,
+    const vector<double> &sensorLat, const vector<double> &sensorLon,
+    const vector<double> &sensorElev, double initLat, double initLon,
+    double initDepth, Core::Time initTime, double &newLat, double &newLon,
+    double &newDepth, Core::Time &newTime, vector<double> &residuals,
+    CovMtrx &covm, bool computeCovMtrx) const {
+
+	SEISCOMP_DEBUG("Start Least Square with initial lat %g lon %g depth %g "
+	               "time %s. Num iterations %d",
+	               initLat, initLon, initDepth, initTime.iso().c_str(),
+	               _currentProfile.leastSquares.iterations);
+
+	if ( !_ttt ) {
+		throw LocatorException(
+		    "Travel time table has not been loaded, check logs");
+	}
+
+	if ( pickList.empty() ) {
+		throw LocatorException("Empty observation set");
+	}
+
+	if ( weights.size() != pickList.size() ||
+	     sensorLat.size() != pickList.size() ||
+	     sensorLon.size() != pickList.size() ||
+	     sensorElev.size() != pickList.size() ) {
+		throw LocatorException("Interna logic error");
+	}
+
+	if ( usingFixedDepth() ) {
+		initDepth = fixedDepth();
+	}
+
+	covm.valid = false;
+
+	residuals.resize(pickList.size());
+
+	vector<double> travelTimes(pickList.size());
 	vector<double> backazis(pickList.size());
 	vector<double> dtdds(pickList.size());
 	vector<double> dtdhs(pickList.size());
 
-	for ( int iteration = 0; iteration <= _currentProfile.leastSquare.iterations;
-	      ++iteration ) {
-		
+	for ( int iteration = 0;
+	      iteration <= _currentProfile.leastSquares.iterations; ++iteration ) {
+
 		// the last additional iteration is for final stats (no inversion)
-		bool lastIteration = (iteration == _currentProfile.leastSquare.iterations);
+		bool lastIteration =
+		    (iteration == _currentProfile.leastSquares.iterations);
 
 		//
 		// Load the information we need to build the Equation System
@@ -1355,7 +1885,7 @@ void StdLoc::locateLeastSquares(
 				continue;
 			}
 
-			// get back azimuth, we don't need the distance, which will 
+			// get back azimuth, we don't need the distance, which will
 			// be discarded (it's a waste of computation)
 			computeDistance(initLat, initLon, sensorLat[i], sensorLon[i],
 			                nullptr, &backazis[i]);
@@ -1363,7 +1893,7 @@ void StdLoc::locateLeastSquares(
 			TravelTime tt;
 
 			try {
-				const char * phaseName = pick->phaseHint().code().c_str();
+				const char *phaseName = pick->phaseHint().code().c_str();
 				if ( _currentProfile.PSTableOnly ) {
 					if ( *pick->phaseHint().code().begin() == 'P' ) {
 						phaseName = "P";
@@ -1375,39 +1905,35 @@ void StdLoc::locateLeastSquares(
 
 				tt = _ttt->compute(phaseName, initLat, initLon, initDepth,
 				                   sensorLat[i], sensorLon[i], sensorElev[i]);
-
 			}
 			catch ( exception &e ) {
-				SEISCOMP_WARNING("Travel Time Table error for %s@%s.%s.%s and lat %.6f "
-				                 "lon %.6f depth %.3f: %s",
-				                 pick->phaseHint().code().c_str(),
-				                 pick->waveformID().networkCode().c_str(),
-				                 pick->waveformID().stationCode().c_str(),
-				                 pick->waveformID().locationCode().c_str(), initLat,
-				                 initLon, initDepth, e.what());
+				SEISCOMP_WARNING(
+				    "Travel Time Table error for %s@%s.%s.%s and lat %g "
+				    "lon %g depth %g: %s",
+				    pick->phaseHint().code().c_str(),
+				    pick->waveformID().networkCode().c_str(),
+				    pick->waveformID().stationCode().c_str(),
+				    pick->waveformID().locationCode().c_str(), initLat, initLon,
+				    initDepth, e.what());
 				throw LocatorException("Travel Time Table error");
 			}
 
-			if ( tt.time < 0 || (tt.time > 0 && tt.dtdd == 0 && tt.dtdh == 0) ) {
-				SEISCOMP_WARNING("Travel Time Table error: data not returned for "
-				                 "%s@%s.%s.%s and lat %.6f lon %.6f depth %.3f",
-				                 pick->phaseHint().code().c_str(),
-				                 pick->waveformID().networkCode().c_str(),
-				                 pick->waveformID().stationCode().c_str(),
-				                 pick->waveformID().locationCode().c_str(), initLat,
-				                 initLon, initDepth);
+			if ( tt.time < 0 ||
+			     (tt.time > 0 && tt.dtdd == 0 && tt.dtdh == 0) ) {
+				SEISCOMP_WARNING(
+				    "Travel Time Table error: data not returned for "
+				    "%s@%s.%s.%s and lat %g lon %g depth %g",
+				    pick->phaseHint().code().c_str(),
+				    pick->waveformID().networkCode().c_str(),
+				    pick->waveformID().stationCode().c_str(),
+				    pick->waveformID().locationCode().c_str(), initLat, initLon,
+				    initDepth);
 				throw LocatorException("Travel Time Table error");
 			}
 
 			travelTimes[i] = tt.time;
 			dtdds[i] = tt.dtdd;
 			dtdhs[i] = tt.dtdh;
-		}
-
-		// the last iteration is use for computing the travelTimes on the final
-		// location and eventually the covariance matrix
-		if ( lastIteration && !computeCovMtrx) {
-			break;
 		}
 
 		//
@@ -1423,11 +1949,15 @@ void StdLoc::locateLeastSquares(
 
 			if ( weights[i] <= 0 ) {
 				eq.W[i] = 0;
+				residuals[i] = 0;
 				continue;
 			}
 
 			Core::Time pickTime = pick->time().value();
-			double residual = (pickTime - (initTime + Core::TimeSpan(travelTimes[i]))).length();
+			double residual =
+			    (pickTime - (initTime + Core::TimeSpan(travelTimes[i])))
+			        .length();
+			residuals[i] = residual;
 			eq.r[i] = residual;
 
 			const double bazi = deg2rad(backazis[i]);
@@ -1435,49 +1965,57 @@ void StdLoc::locateLeastSquares(
 			eq.G[i][1] = dtdds[i] * cos(bazi); // dy [sec/deg]
 			eq.G[i][2] = dtdhs[i];             // dz [sec/km]
 			eq.G[i][3] = 1.;                   // dtime [sec]
+
+			if ( usingFixedDepth() ) {
+				eq.G[i][2] = 0;                  // dz [sec/km]
+			}
 		}
 
-		if ( lastIteration && computeCovMtrx) {
-			computeCovarianceMatrix(eq, covm);
+		// the last iteration is use for computing the residuals on the final
+		// location and eventually the covariance matrix
+		if ( lastIteration ) {
+			if ( computeCovMtrx ) {
+				computeCovarianceMatrix(eq, covm);
+			}
 			break;
 		}
- 
+
 		//
 		// Solve the system
 		//
 		try {
 			ostringstream solverLogs;
-			if ( _currentProfile.leastSquare.solverType == "LSMR" ) {
+			if ( _currentProfile.leastSquares.solverType == "LSMR" ) {
 				// solve
-				Adapter<lsmrBase> solver = solve<lsmrBase>(
-					eq, &solverLogs, _currentProfile.leastSquare.dampingFactor
-				);
+				Adapter<lsmrBase> solver =
+				    solve<lsmrBase>(eq, &solverLogs,
+				                    _currentProfile.leastSquares.dampingFactor);
 				// print some information
-				SEISCOMP_DEBUG("Solver stopped because %u : %s (used %u iterations)",
-				               solver.GetStoppingReason(),
-				               solver.GetStoppingReasonMessage().c_str(),
-				               solver.GetNumberOfIterationsPerformed());
+				SEISCOMP_DEBUG(
+				    "Solver stopped because %u : %s (used %u iterations)",
+				    solver.GetStoppingReason(),
+				    solver.GetStoppingReasonMessage().c_str(),
+				    solver.GetNumberOfIterationsPerformed());
 			}
-			else if ( _currentProfile.leastSquare.solverType == "LSQR" ) {
+			else if ( _currentProfile.leastSquares.solverType == "LSQR" ) {
 				// solve
-				Adapter<lsqrBase> solver = solve<lsqrBase>(
-					eq, &solverLogs, _currentProfile.leastSquare.dampingFactor
-				);
+				Adapter<lsqrBase> solver =
+				    solve<lsqrBase>(eq, &solverLogs,
+				                    _currentProfile.leastSquares.dampingFactor);
 				// print some information
-				SEISCOMP_DEBUG("Solver stopped because %u : %s (used %u iterations)",
-				               solver.GetStoppingReason(),
-				               solver.GetStoppingReasonMessage().c_str(),
-				               solver.GetNumberOfIterationsPerformed());
+				SEISCOMP_DEBUG(
+				    "Solver stopped because %u : %s (used %u iterations)",
+				    solver.GetStoppingReason(),
+				    solver.GetStoppingReasonMessage().c_str(),
+				    solver.GetNumberOfIterationsPerformed());
 			}
 			else {
 				throw LocatorException(
-					"Solver type can only be LSMR or LSQR, but it is set to" +
-					_currentProfile.leastSquare.solverType
-				);
+				    "Solver type can only be LSMR or LSQR, but it is set to" +
+				    _currentProfile.leastSquares.solverType);
 			}
 
 			SEISCOMP_DEBUG("Solver logs:\n%s", solverLogs.str().c_str());
-
 		}
 		catch ( exception &e ) {
 			throw LocatorException(e.what());
@@ -1493,7 +2031,8 @@ void StdLoc::locateLeastSquares(
 
 		if ( !isfinite(lonCorrection) || !isfinite(latCorrection) ||
 		     !isfinite(depthCorrection) || !isfinite(timeCorrection) ) {
-			throw LocatorException("Couldn't find a solution to the equation system");
+			throw LocatorException(
+			    "Couldn't find a solution to the equation system");
 		}
 
 		newLat = initLat + latCorrection;
@@ -1501,12 +2040,12 @@ void StdLoc::locateLeastSquares(
 		newTime = initTime + Core::TimeSpan(timeCorrection);
 		newDepth = initDepth + depthCorrection;
 
-		SEISCOMP_DEBUG("Least Square iteration %d: corrections lat %f [km] lon %f [km] "
-		               "depth %f [km] time %f [sec]. New source parameters lat %.6f "
-		               "lon %.6f depth %.3f time %s",
-		               iteration, latCorrection, lonCorrection, depthCorrection,
-		               timeCorrection, newLat, newLon, newDepth,
-		               newTime.iso().c_str());
+		SEISCOMP_DEBUG(
+		    "Least Square iteration %d: corrections lat %f [km] lon %f [km] "
+		    "depth %f [km] time %f [sec]. New source parameters lat %g "
+		    "lon %g depth %g time %s",
+		    iteration, latCorrection, lonCorrection, depthCorrection,
+		    timeCorrection, newLat, newLon, newDepth, newTime.iso().c_str());
 
 		//
 		// set the initial values for the next iteration
@@ -1517,8 +2056,8 @@ void StdLoc::locateLeastSquares(
 		initTime = newTime;
 	}
 
-	SEISCOMP_DEBUG("Least Square final solution lat %.6f lon %.6f "
-	               "depth %.3f time %s",
+	SEISCOMP_DEBUG("Least Square final solution lat %g lon %g "
+	               "depth %g time %s",
 	               newLat, newLon, newDepth, newTime.iso().c_str());
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -1527,70 +2066,77 @@ void StdLoc::locateLeastSquares(
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-void StdLoc::computeCovarianceMatrix(const vector<Cell>& cells,
-                                     const Cell& bestCell,
-                                     CovMtrx& covm) const {
+void StdLoc::computeCovarianceMatrix(const vector<Cell> &cells,
+                                     const Cell &bestCell,
+                                     bool useExpectedHypocenter,
+                                     CovMtrx &covm) const {
 	covm.valid = false;
 
-	auto toWeight = [&bestCell](double error) {
-		return std::exp(-0.5*error/bestCell.org.error);
+	auto normalize = [&bestCell](const Cell &cell) {
+		return cell.org.probDensity / bestCell.org.probDensity;
 	};
 
-	double wmeanLat = 0, wmeanLon = 0, wmeanDepth = 0, wmeanTime = 0;
-	//vector<double> longitudes;
-	//vector<double> weights;
-
-	//for ( const Cell& cell : cells ) {
-	//	if ( !cell.valid ) {
-	//		continue;
-	//	}
-	//	double weight = toWeight(cell.org.error);
-	//	weightSum += weight;
-	//	wmeanLat += cell.org.lat * weight;
-	//	wmeanDepth += cell.org.depth * weight;
-	//	wmeanTime += static_cast<double>(cell.org.time) * weight;
-	//	longitudes.push_back(cell.org.lon);
-	//	weights.push_back(weight);
-	//}
-	//wmeanLat /= weightSum;
-	//wmeanDepth /= weightSum;
-	//wmeanTime /= weightSum;
-	//wmeanLon = Geo::GeoCoordinate::normalizeLon(
-	//	 computedWeightedCircularMean(longitudes, weights, false)
-	//);
-
 	//
-	// The covaraiance should be computed using the expected values
-	// that is the weigheted mean of lat, lon, depth and time
+	// The covariance should be computed using the expected hypocenter
+	// (that is the weigheted mean of lat, lon, depth and time)
 	// However the confidence ellipsoid is considered w.r.t. the
-	// origin location, so we compute the covariance matrix
-	// w.r.t. to the origin location (bestCell)
+	// maximum likelihood hypocenter (i.e. bestCell).
+	// So the useExpectedHypocenter allow to control the reference hypocenter
+	// to use for computing the covariance matrix
 	//
-	wmeanLat = bestCell.org.lat;
-	wmeanLon = bestCell.org.lon;
-	wmeanDepth = bestCell.org.depth;
-	wmeanTime = static_cast<double>(bestCell.org.time);
-
+	double wmeanLat = 0, wmeanLon = 0, wmeanDepth = 0, wmeanTime = 0;
 	double weightSum = 0.0;
-	std::array<std::array<double,4>,4> m = {};
-	for ( const Cell& cell : cells ) {
+	if ( useExpectedHypocenter ) {
+		vector<double> longitudes;
+		vector<double> weights;
+
+		for ( const Cell &cell : cells ) {
+			if ( !cell.valid ) {
+				continue;
+			}
+			double weight = normalize(cell);
+			weightSum += weight;
+			wmeanLat += cell.org.lat * weight;
+			wmeanDepth += cell.org.depth * weight;
+			wmeanTime += static_cast<double>(cell.org.time) * weight;
+			longitudes.push_back(cell.org.lon);
+			weights.push_back(weight);
+		}
+		wmeanLat /= weightSum;
+		wmeanDepth /= weightSum;
+		wmeanTime /= weightSum;
+		wmeanLon = Geo::GeoCoordinate::normalizeLon(
+		    computedWeightedCircularMean(longitudes, weights, false));
+	}
+	else {
+		wmeanLat = bestCell.org.lat;
+		wmeanLon = bestCell.org.lon;
+		wmeanDepth = bestCell.org.depth;
+		wmeanTime = static_cast<double>(bestCell.org.time);
+	}
+
+	weightSum = 0.0;
+	std::array<std::array<double, 4>, 4> m = {};
+	for ( const Cell &cell : cells ) {
 		if ( !cell.valid ) {
 			continue;
 		}
-		double weight = toWeight(cell.org.error);
+		double weight = normalize(cell);
 		weightSum += weight;
-		double rLon = computeDistance(cell.org.lat, cell.org.lon, 
-		                              cell.org.lat, wmeanLon);
-		if ( cell.org.lon > wmeanLon) {
+		double rLon =
+		    computeDistance(cell.org.lat, cell.org.lon, cell.org.lat, wmeanLon);
+		if ( cell.org.lon > wmeanLon ) {
 			rLon = Math::Geo::deg2km(rLon);
-		} else {
+		}
+		else {
 			rLon = -Math::Geo::deg2km(rLon);
 		}
-		double rLat = computeDistance(cell.org.lat, cell.org.lon,
-		                              wmeanLat, cell.org.lon);
-		if ( cell.org.lat > wmeanLat) {
+		double rLat =
+		    computeDistance(cell.org.lat, cell.org.lon, wmeanLat, cell.org.lon);
+		if ( cell.org.lat > wmeanLat ) {
 			rLat = Math::Geo::deg2km(rLat);
-		} else {
+		}
+		else {
 			rLat = -Math::Geo::deg2km(rLat);
 		}
 		double rDepth = cell.org.depth - wmeanDepth;
@@ -1648,9 +2194,9 @@ void StdLoc::computeCovarianceMatrix(const vector<Cell>& cells,
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-void StdLoc::computeCovarianceMatrix(const System& eq, CovMtrx& covm) const {
+void StdLoc::computeCovarianceMatrix(const System &eq, CovMtrx &covm) const {
 	//
-	// Accordingly to "Routine Data Processing in Earthquake Seismology" 
+	// Accordingly to "Routine Data Processing in Earthquake Seismology"
 	// by Jens Havskov and Lars Ottemoller, the covariance matrix can be
 	// computed as:
 	//
@@ -1676,7 +2222,8 @@ void StdLoc::computeCovarianceMatrix(const System& eq, CovMtrx& covm) const {
 	covm.valid = false;
 
 	if ( eq.numRowsG <= 4 ) {
-		SEISCOMP_DEBUG("Cannot compute covariance matrix: less than 5 arrivals");
+		SEISCOMP_DEBUG(
+		    "Cannot compute covariance matrix: less than 5 arrivals");
 		return;
 	}
 
@@ -1684,9 +2231,9 @@ void StdLoc::computeCovarianceMatrix(const System& eq, CovMtrx& covm) const {
 	for ( unsigned int ob = 0; ob < eq.numRowsG; ob++ ) {
 		sigma2 += eq.r[ob] * eq.r[ob];
 	}
-	sigma2 /= eq.numRowsG-4;
+	sigma2 /= eq.numRowsG - 4;
 
-	std::array<std::array<double,4>,4> GtG = {}; // G.T * G
+	std::array<std::array<double, 4>, 4> GtG = {}; // G.T * G
 	for ( unsigned int ob = 0; ob < eq.numRowsG; ob++ ) {
 		double gLon = eq.G[ob][0] / KM_OF_DEGREE;
 		double gLat = eq.G[ob][1] / KM_OF_DEGREE;
@@ -1710,9 +2257,10 @@ void StdLoc::computeCovarianceMatrix(const System& eq, CovMtrx& covm) const {
 		GtG[3][3] += gTime  * gTime;
 	}
 
-	std::array<std::array<double,4>,4> inverseGtG;
-	if ( ! invertMatrix4x4(GtG, inverseGtG) ) {
-		SEISCOMP_DEBUG("Cannot compute covariance matrix: G.T*G not invertible");
+	std::array<std::array<double, 4>, 4> inverseGtG;
+	if ( !invertMatrix4x4(GtG, inverseGtG) ) {
+		SEISCOMP_DEBUG(
+		    "Cannot compute covariance matrix: G.T*G not invertible");
 		return;
 	}
 
@@ -1735,12 +2283,11 @@ void StdLoc::computeCovarianceMatrix(const System& eq, CovMtrx& covm) const {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 Origin *StdLoc::createOrigin(
-	const PickList &pickList, const vector<double> &weights,
-	const vector<double> &sensorLat, const vector<double> &sensorLon,
-	const vector<double> &sensorElev, double originLat, double originLon,
-	double originDepth, const Core::Time &originTime,
-	const vector<double> &travelTimes, const CovMtrx& covm
-) const {
+    const PickList &pickList, const vector<double> &weights,
+    const vector<double> &sensorLat, const vector<double> &sensorLon,
+    const vector<double> &sensorElev, double originLat, double originLon,
+    double originDepth, const Core::Time &originTime,
+    const vector<double> &residuals, const CovMtrx &covm) const {
 	if ( weights.size() != pickList.size() ) {
 		throw LocatorException("Internal logic error");
 	}
@@ -1751,9 +2298,24 @@ Origin *StdLoc::createOrigin(
 	Origin *origin = Origin::Create();
 	SEISCOMP_DEBUG("New origin publicID: %s", origin->publicID().c_str());
 
+	if ( _currentProfile.method == Profile::Method::LeastSquares ) {
+		origin->setMethodID("StdLoc:LeastSquares");
+	}
+	else if ( _currentProfile.method == Profile::Method::GridSearch ) {
+		origin->setMethodID("StdLoc:GridSearch");
+	}
+	else if ( _currentProfile.method == Profile::Method::OctTree ) {
+		origin->setMethodID("StdLoc:OctTree");
+	}
+	else if ( _currentProfile.method == Profile::Method::GridAndLsqr ) {
+		origin->setMethodID("StdLoc:GridSearch+LeastSquares");
+	}
+	else if ( _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+		origin->setMethodID("StdLoc:OctTree+LeastSquares");
+	}
+
 	origin->setCreationInfo(ci);
 	origin->setEarthModelID(_tttType + ":" + _tttModel);
-	origin->setMethodID("StdLoc");
 	origin->setTime(DataModel::TimeQuantity(originTime));
 	origin->setLatitude(DataModel::RealQuantity(originLat));
 	origin->setLongitude(DataModel::RealQuantity(originLon));
@@ -1772,20 +2334,18 @@ Origin *StdLoc::createOrigin(
 		const PickItem &pi = pickList[i];
 		const PickPtr pick = pi.pick;
 
-		Core::Time pickTime = pick->time().value();
-
 		++associatedPhaseCount;
 		associatedStations.insert(pick->waveformID().networkCode() + "." +
 		                          pick->waveformID().stationCode() + "." +
 		                          pick->waveformID().locationCode());
 
 		double azimuth = 0;
-		double Hdist = computeDistance(originLat, originLon,
-		                               sensorLat[i], sensorLon[i],
-		                               &azimuth);
+		double Hdist = computeDistance(originLat, originLon, sensorLat[i],
+		                               sensorLon[i], &azimuth);
 		Hdist = Math::Geo::deg2km(Hdist);
 		double Vdist = abs(originDepth + sensorElev[i] / 1000);
-		double distance = Math::Geo::km2deg(sqrt(Hdist * Hdist + Vdist * Vdist));
+		double distance =
+		    Math::Geo::km2deg(sqrt(Hdist * Hdist + Vdist * Vdist));
 
 		// prepare the new arrival
 		DataModel::Arrival *newArr = new DataModel::Arrival();
@@ -1807,11 +2367,10 @@ Origin *StdLoc::createOrigin(
 			newArr->setTimeUsed(true);
 			newArr->setWeight(weights[i]);
 
-			double residual =
-			    (pickTime - (originTime + Core::TimeSpan(travelTimes[i]))).length();
-			newArr->setTimeResidual(residual);
+			newArr->setTimeResidual(residuals[i]);
 
-			sumSquaredResiduals += (residual * weights[i]) * (residual * weights[i]);
+			sumSquaredResiduals +=
+			    (residuals[i] * weights[i]) * (residuals[i] * weights[i]);
 			sumSquaredWeights += weights[i] * weights[i];
 
 			usedPhaseCount++;
@@ -1868,152 +2427,177 @@ Origin *StdLoc::createOrigin(
 	// The Confidence Ellipsoid code has been adapted from LOCSAT locator
 	//
 	if ( _currentProfile.enableConfidenceEllipsoid ) {
-	
-		if ( ! covm.valid ) {
-			SEISCOMP_DEBUG("No valid covariance matrix. No Confidence ellipsoid will be computed");
-		} else {
 
-		// M4d is the 4D matrix with X axis as S-N and Y axis as W-E
-		double M4d[16] = {
-			covm.syy, covm.sxy, covm.syz, covm.syt,
-			covm.sxy, covm.sxx, covm.sxz, covm.sxt,
-			covm.syz, covm.sxz, covm.szz, covm.szt,
-			covm.syt, covm.sxt, covm.szt, covm.stt
-		};
-
-		// M3d is the matrix in space
-		double M3d[9] = {
-			M4d[0], M4d[1], M4d[2],
-			M4d[4], M4d[5], M4d[6],
-			M4d[8], M4d[9], M4d[10]
-		};
-
-		// M2d is the matrix in the XY plane
-		double M2d[4] = {
-			M4d[0], M4d[1],
-			M4d[4], M4d[5]
-		};
-
-		// Diagonalize 3D and 2D matrixes
-		// We use EISPACK code
-
-		// compute 3D and 2D eigenvalues, eigenvectors
-		// EISPACK sort eigenvalues from min to max
-		int ierr3;
-		double eigvec3d[9];
-		double eigval3d[3];
-		ierr3 = rs(3, M3d, eigval3d, eigvec3d);
-
-		int ierr2;
-		double eigvec2d[4];
-		double eigval2d[2];
-		ierr2 = rs(2, M2d, eigval2d, eigvec2d);
-
-		/*
-		* Confidence coefficients for 1D, 2D and 3D
-		* 
-		* We use ASA091 code
-		*
-		* The following table summarizes confidence coefficients for 0.90 (LocSAT) and 0.68 (NonLinLoc) confidence levels
-		*
-		* confidenceLevel      1D             2D              3D
-		*      0.90        1.6448536270    2.1459660263    2.5002777108
-		*      0.68        0.9944578832    1.5095921855    1.8724001591
-		*
-		*
-		*/
-
-		if ( ierr3 == 0 && ierr2 == 0 ) {
-			double kppf[3];
-			double g;
-			int ifault;
-			double dof;
-
-			for ( int i = 0; i < 3; ++i ) {
-				dof = i + 1;
-				g = alngam(dof/2.0, &ifault);
-				kppf[i] = pow(ppchi2(_currentProfile.confLevel, dof, g, &ifault), 0.5);
-			}
-
-			double sx, sy, smajax, sminax, strike;
-
-			// 1D confidence intervals
-			sx = kppf[0] * pow(M4d[0], 0.5); // sxx
-			sy = kppf[0] * pow(M4d[5], 0.5); // syy
-
-			// 1D confidence intervals
-			origin->setTime(DataModel::TimeQuantity(originTime, sqrt(covm.stt) * kppf[0], Core::None, Core::None, _currentProfile.confLevel * 100.0));
-			origin->setLatitude(DataModel::RealQuantity(originLat, sqrt(covm.syy) * kppf[0], Core::None, Core::None, _currentProfile.confLevel * 100.0));
-			origin->setLongitude(DataModel::RealQuantity(originLon, sqrt(covm.sxx) * kppf[0], Core::None, Core::None, _currentProfile.confLevel * 100.0));
-			origin->setDepth(DataModel::RealQuantity(originDepth, sqrt(covm.szz) * kppf[0], Core::None, Core::None, _currentProfile.confLevel * 100.0));
-
-			// 2D confidence intervals
-			sminax = kppf[1] * pow(eigval2d[0], 0.5);
-			smajax = kppf[1] * pow(eigval2d[1], 0.5);
-			strike = rad2deg(atan(eigvec2d[3] / eigvec2d[2]));
-			// give the strike in the [0.0, 180.0] interval
-			if ( strike < 0.0 )
-				strike += 180.0;
-
-			if ( strike > 180.0 )
-				strike -= 180.0;
-
-			// 3D confidence intervals
-			double s3dMajAxis, s3dMinAxis, s3dIntAxis, MajAxisPlunge, MajAxisAzimuth, MajAxisRotation;
-
-			s3dMinAxis = kppf[2] * pow(eigval3d[0], 0.5);
-			s3dIntAxis = kppf[2] * pow(eigval3d[1], 0.5);
-			s3dMajAxis = kppf[2] * pow(eigval3d[2], 0.5);
-
-			MajAxisPlunge   = rad2deg(atan(eigvec3d[8] / pow(pow(eigvec3d[6], 2.0) + pow(eigvec3d[7], 2.0), 0.5)));
-			if ( MajAxisPlunge < 0.0 )
-				MajAxisPlunge += 180.0;
-
-			if ( MajAxisPlunge > 180.0 )
-				MajAxisPlunge -= 180.0;
-
-			MajAxisAzimuth  = rad2deg(atan(eigvec3d[7] / eigvec3d[6]));
-			if ( MajAxisAzimuth < 0.0 )
-				MajAxisAzimuth += 180.0;
-
-			if ( MajAxisAzimuth > 180.0 )
-				MajAxisAzimuth -= 180.0;
-
-			MajAxisRotation = rad2deg(atan(eigvec3d[2] / pow(pow(eigvec3d[0], 2.0) + pow(eigvec3d[1], 2.0), 0.5)));
-			if ( covm.szz == 0.0 )
-				MajAxisRotation = 0.0;
-
-			if ( MajAxisRotation < 0.0 )
-				MajAxisRotation += 180.0;
-
-			if ( MajAxisRotation > 180.0 )
-				MajAxisRotation -= 180.0;
-
-			DataModel::ConfidenceEllipsoid confidenceEllipsoid;
-			DataModel::OriginUncertainty originUncertainty;
-
-			confidenceEllipsoid.setSemiMinorAxisLength(s3dMinAxis*1000.0);
-			confidenceEllipsoid.setSemiIntermediateAxisLength(s3dIntAxis*1000.0);
-			confidenceEllipsoid.setSemiMajorAxisLength(s3dMajAxis*1000.0);
-			confidenceEllipsoid.setMajorAxisPlunge(MajAxisPlunge);
-			confidenceEllipsoid.setMajorAxisAzimuth(MajAxisAzimuth);
-			confidenceEllipsoid.setMajorAxisRotation(MajAxisRotation);
-
-			// QuakeML, horizontalUncertainty: Circular confidence region, given by single value of horizontal uncertainty.
-			// Acordingly, 1D horizontal errors quadratic mean is given
-			originUncertainty.setHorizontalUncertainty(sqrt(pow(sx, 2) + pow(sy, 2)));
-			originUncertainty.setMinHorizontalUncertainty(sminax);
-			originUncertainty.setMaxHorizontalUncertainty(smajax);
-			originUncertainty.setAzimuthMaxHorizontalUncertainty(strike);
-			originUncertainty.setConfidenceEllipsoid(confidenceEllipsoid);
-			originUncertainty.setPreferredDescription(Seiscomp::DataModel::OriginUncertaintyDescription(Seiscomp::DataModel::ELLIPSOID));
-
-			origin->setUncertainty(originUncertainty);
-
+		if ( !covm.valid ) {
+			SEISCOMP_DEBUG(
+			    "No valid covariance matrix. No Confidence ellipsoid will "
+			    "be computed");
 		}
 		else {
-			SEISCOMP_DEBUG("Unable to calculate eigenvalues/eigenvectors. No Confidence ellipsoid will be computed");
-		}
+
+			// M4d is the 4D matrix with X axis as S-N and Y axis as W-E
+			double M4d[16] = {
+				covm.syy, covm.sxy, covm.syz, covm.syt,
+				covm.sxy, covm.sxx, covm.sxz, covm.sxt,
+				covm.syz, covm.sxz, covm.szz, covm.szt,
+				covm.syt, covm.sxt, covm.szt, covm.stt
+			};
+
+				// M3d is the matrix in space
+			double M3d[9] = {
+				M4d[0], M4d[1], M4d[2],
+				M4d[4], M4d[5], M4d[6],
+				M4d[8], M4d[9], M4d[10]
+			};
+
+				// M2d is the matrix in the XY plane
+			double M2d[4] = {
+				M4d[0], M4d[1],
+				M4d[4], M4d[5]
+			};
+
+			// Diagonalize 3D and 2D matrixes
+			// We use EISPACK code
+
+			// compute 3D and 2D eigenvalues, eigenvectors
+			// EISPACK sort eigenvalues from min to max
+			int ierr3;
+			double eigvec3d[9];
+			double eigval3d[3];
+			ierr3 = rs(3, M3d, eigval3d, eigvec3d);
+
+			int ierr2;
+			double eigvec2d[4];
+			double eigval2d[2];
+			ierr2 = rs(2, M2d, eigval2d, eigvec2d);
+
+			/*
+			 * Confidence coefficients for 1D, 2D and 3D
+			 *
+			 * We use ASA091 code
+			 *
+			 * The following table summarizes confidence coefficients for 0.90
+			 * (LocSAT) and 0.68 (NonLinLoc) confidence levels
+			 *
+			 * confidenceLevel      1D             2D              3D
+			 *      0.90        1.6448536270    2.1459660263    2.5002777108
+			 *      0.68        0.9944578832    1.5095921855    1.8724001591
+			 *
+			 *
+			 */
+
+			if ( ierr3 == 0 && ierr2 == 0 ) {
+				double kppf[3];
+				double g;
+				int ifault;
+				double dof;
+
+				for ( int i = 0; i < 3; ++i ) {
+					dof = i + 1;
+					g = alngam(dof / 2.0, &ifault);
+					kppf[i] =
+					    pow(ppchi2(_currentProfile.confLevel, dof, g, &ifault),
+					        0.5);
+				}
+
+				double sx, sy, smajax, sminax, strike;
+
+				// 1D confidence intervals
+				sx = kppf[0] * pow(M4d[0], 0.5); // sxx
+				sy = kppf[0] * pow(M4d[5], 0.5); // syy
+
+				// 1D confidence intervals
+				origin->setTime(DataModel::TimeQuantity(
+				    originTime, sqrt(covm.stt) * kppf[0], Core::None,
+				    Core::None, _currentProfile.confLevel * 100.0));
+				origin->setLatitude(DataModel::RealQuantity(
+				    originLat, sqrt(covm.syy) * kppf[0], Core::None, Core::None,
+				    _currentProfile.confLevel * 100.0));
+				origin->setLongitude(DataModel::RealQuantity(
+				    originLon, sqrt(covm.sxx) * kppf[0], Core::None, Core::None,
+				    _currentProfile.confLevel * 100.0));
+				origin->setDepth(DataModel::RealQuantity(
+				    originDepth, sqrt(covm.szz) * kppf[0], Core::None,
+				    Core::None, _currentProfile.confLevel * 100.0));
+
+				// 2D confidence intervals
+				sminax = kppf[1] * pow(eigval2d[0], 0.5);
+				smajax = kppf[1] * pow(eigval2d[1], 0.5);
+				strike = rad2deg(atan(eigvec2d[3] / eigvec2d[2]));
+				// give the strike in the [0.0, 180.0] interval
+				if ( strike < 0.0 )
+					strike += 180.0;
+
+				if ( strike > 180.0 )
+					strike -= 180.0;
+
+				// 3D confidence intervals
+				double s3dMajAxis, s3dMinAxis, s3dIntAxis, MajAxisPlunge,
+				    MajAxisAzimuth, MajAxisRotation;
+
+				s3dMinAxis = kppf[2] * pow(eigval3d[0], 0.5);
+				s3dIntAxis = kppf[2] * pow(eigval3d[1], 0.5);
+				s3dMajAxis = kppf[2] * pow(eigval3d[2], 0.5);
+
+				MajAxisPlunge = rad2deg(atan(
+				    eigvec3d[8] /
+				    pow(pow(eigvec3d[6], 2.0) + pow(eigvec3d[7], 2.0), 0.5)));
+				if ( MajAxisPlunge < 0.0 )
+					MajAxisPlunge += 180.0;
+
+				if ( MajAxisPlunge > 180.0 )
+					MajAxisPlunge -= 180.0;
+
+				MajAxisAzimuth = rad2deg(atan(eigvec3d[7] / eigvec3d[6]));
+				if ( MajAxisAzimuth < 0.0 )
+					MajAxisAzimuth += 180.0;
+
+				if ( MajAxisAzimuth > 180.0 )
+					MajAxisAzimuth -= 180.0;
+
+				MajAxisRotation = rad2deg(atan(
+				    eigvec3d[2] /
+				    pow(pow(eigvec3d[0], 2.0) + pow(eigvec3d[1], 2.0), 0.5)));
+				if ( covm.szz == 0.0 )
+					MajAxisRotation = 0.0;
+
+				if ( MajAxisRotation < 0.0 )
+					MajAxisRotation += 180.0;
+
+				if ( MajAxisRotation > 180.0 )
+					MajAxisRotation -= 180.0;
+
+				DataModel::ConfidenceEllipsoid confidenceEllipsoid;
+				DataModel::OriginUncertainty originUncertainty;
+
+				confidenceEllipsoid.setSemiMinorAxisLength(s3dMinAxis * 1000.0);
+				confidenceEllipsoid.setSemiIntermediateAxisLength(s3dIntAxis *
+				                                                  1000.0);
+				confidenceEllipsoid.setSemiMajorAxisLength(s3dMajAxis * 1000.0);
+				confidenceEllipsoid.setMajorAxisPlunge(MajAxisPlunge);
+				confidenceEllipsoid.setMajorAxisAzimuth(MajAxisAzimuth);
+				confidenceEllipsoid.setMajorAxisRotation(MajAxisRotation);
+
+				// QuakeML, horizontalUncertainty: Circular confidence region,
+				// given by single value of horizontal uncertainty. Acordingly,
+				// 1D horizontal errors quadratic mean is given
+				originUncertainty.setHorizontalUncertainty(
+				    sqrt(pow(sx, 2) + pow(sy, 2)));
+				originUncertainty.setMinHorizontalUncertainty(sminax);
+				originUncertainty.setMaxHorizontalUncertainty(smajax);
+				originUncertainty.setAzimuthMaxHorizontalUncertainty(strike);
+				originUncertainty.setConfidenceEllipsoid(confidenceEllipsoid);
+				originUncertainty.setPreferredDescription(
+				    Seiscomp::DataModel::OriginUncertaintyDescription(
+				        Seiscomp::DataModel::ELLIPSOID));
+
+				origin->setUncertainty(originUncertainty);
+			}
+			else {
+				SEISCOMP_DEBUG(
+				    "Unable to calculate eigenvalues/eigenvectors. No "
+				    "Confidence ellipsoid will be computed");
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR completes all the features I wanted to add to the locator. I will focus on bug fixing now. Not that I am aware of any bugs, but it's a young software so the bugs are there for sure. I am currently using the locator on two projects so I am actively looking at the results and hopefully I should find out if there are major issues.

Anyhow, here is the list of changes:
- add `OctTree` and `OctTree+LeastSquares` as optional methods.
- remove `IgnoreInitialLocation` capability from the locator. This is because the initial location either is not used (`GridSearch` and `OctTree` search) or is mandatory (`LeastSquare`). So it doesn't make sense to make it optional in `scolv`.
- add `FixedDepth` capability. This is certainly useful is several cases.
- Remove `GridSearch.maxRms` configuration. That was an idea that I had, but It turned out to be pointless.
- change default travel time table to `LOCSAT` (it was `libtau`)
