### PR TITLE
[logging] avoid declaration of 'expect' macro

### DIFF
--- a/libs/seiscomp/logging/common.h
+++ b/libs/seiscomp/logging/common.h
@@ -40,10 +40,8 @@
 */
 #ifdef __GNUC__
 
-# define expect(foo, bar) __builtin_expect((foo),bar)
-
-# define   likely(x)  expect((x),1)
-# define unlikely(x)  expect((x),0)
+# define   likely(x)  __builtin_expect((x),1)
+# define unlikely(x)  __builtin_expect((x),0)
 
 #else
 


### PR DESCRIPTION
Calling a macro with such a common word (expect) easily results in code breakage. The macro is not even useful (it might have been useful in the past).

I would suggest to completely remove the macro.