### PR TITLE
[quakeml] fix invalid ResourceUri

### DIFF
--- a/libs/seiscomp/datamodel/exchange/quakeml.cpp
+++ b/libs/seiscomp/datamodel/exchange/quakeml.cpp
@@ -469,8 +469,9 @@ struct ArrivalPublicIDHandler : IO::XML::MemberHandler {
 	std::string value(Core::BaseObject *obj) override {
 		Arrival *arrival = Arrival::Cast(obj);
 		if ( arrival && arrival->origin() ) {
-			std::string oid = arrival->origin()->publicID();
-			return SMI_PREFIX + arrival->pickID() + "_" + replaceIDChars(oid);
+			auto pid = arrival->pickID();
+			auto oid = arrival->origin()->publicID();
+			return SMI_PREFIX + replaceIDChars(pid) + "_" + replaceIDChars(oid);
 		}
 		return SMI_PREFIX + "NA";
 	}


### PR DESCRIPTION
When using obspy.client to retrieve data there is a user warning for each arrival. The arrivals in quakeml-format do not have a valid publicID.

UserWarning: 'smi:org.gfz-potsdam.de/geofon/smi:local/LED/pick/6b98ba97-c5b1-4488-ae7c-29752b40e0fb_smi_local/LED/c4c35d6d-cd06-4596-bcd8-0956f155c935' is not a valid QuakeML URI. It will be in the final file but note that the file will not be a valid QuakeML file.