### PR TITLE
[locator] fix possible infinite loop in locator uncertainty computation

### DIFF
--- a/libs/seiscomp/seismology/locator/eigv.cpp
+++ b/libs/seiscomp/seismology/locator/eigv.cpp
@@ -18,6 +18,7 @@
  ***************************************************************************/
 #include <iostream>
 #include <math.h>
+#include <limits>
 using namespace std;
 #include "eigv.h"
 
@@ -328,6 +329,10 @@ double pythag ( double a, double b )
   double s;
   double t;
   double u;
+
+  if ( !std::isfinite(a) || !std::isfinite(b) ) {
+     return std::numeric_limits<double>::quiet_NaN();
+  }
 
   p = r8_max ( r8_abs ( a ), r8_abs ( b ) );
 


### PR DESCRIPTION
This bug affects `LOCSAT` and `StdLoc`.

I noticed this infinite loop because `StdLoc` enables the confidence ellipsoid by default (LOCSAT has it disabled). Since I am working on  playbacks with tens of thousands of events the bug became apparent.

I don't know why they implemented the original code in that way, but they must have had a good reason. So I am not super happy to change the implementation, but the possible infinite loop is way too problematic. I'll let you decide what to do.

Here is a naive test for the changed code, in case you want to play around with it:

```
#include <iostream>
#include <cmath>

using namespace std;

/*
 * Code copied from common/libs/seiscomp/seismology/locator/eigv.cpp
 */
double r8_max ( double x, double y )
{
  double value;

  if ( y < x )
  {
    value = x;
  }
  else
  {
    value = y;
  }
  return value;
}

double r8_min ( double x, double y )
{
  double value;

  if ( y < x )
  {
    value = y;
  }
  else
  {
    value = x;
  }
  return value;
}

double r8_abs ( double x )
{
  double value;

  if ( 0.0 <= x )
  {
    value = + x;
  }
  else
  {
    value = - x;
  }
  return value;
}

double pythag ( double a, double b )
{
  double p;
  double r;
  double s;
  double t;
  double u;

  p = r8_max ( r8_abs ( a ), r8_abs ( b ) );

  if ( p != 0.0 )
  {
    r = r8_min ( r8_abs ( a ), r8_abs ( b ) ) / p;
    r = r * r;

    while ( 1 )
    {
      t = 4.0 + r;

      if ( t == 4.0 )
      {
        break;
      }

      s = r / t;
      u = 1.0 + 2.0 * s;
      p = u * p;
      r = ( s / u ) * ( s / u ) * r;
    }
  }
  return p;
}

/*
 * Simple test to compare the 2 implementations
 */
void compare(double percentDiff, double rangeA, double rangeB, double stepA, double stepB)
{
  for (double a = -rangeA; a <= rangeB; a +=stepA)
    for (double b = -rangeB; b <= rangeB; b +=stepB)
    {
      double ref = pythag(a,b);
      double alt = sqrt(a*a+b*b);
      double diff = ref-alt;
      if ( fabs(diff/ref) > percentDiff )
      {
        cout << diff << " " << ref << " " << alt << endl;
      }
    }
}

int main()
{
  const double percentDiff = 0.000000000000001;

  compare(percentDiff, 1e20, 1e20, 1e17, 1e17);
  compare(percentDiff, 1e10, 1e10, 1e7, 1e7);
  compare(percentDiff, 1e3, 1e3, 1, 1);

  compare(percentDiff, 1, 1, 1e-3, 1e-3);
  compare(percentDiff, 1e-7, 1e-7, 1e-10, 1e-10);
  compare(percentDiff, 1e-17, 1e-17, 1e-20, 1e-20);

  compare(percentDiff, 1e20, 1e-17, 1e17, 1e-20);
  compare(percentDiff, 1e10, 1e-7, 1e7, 1e-10);
  compare(percentDiff, 1e3, 1, 1, 1e-3);
  return 0;
}


```