### PR TITLE
[core] allow null arguments to Seiscomp::Math::Geo::delazi

### DIFF
--- a/libs/seiscomp/math/geo.h
+++ b/libs/seiscomp/math/geo.h
@@ -36,6 +36,13 @@ namespace Geo
 
 /**
  * For two points (lat1, lon1) and (lat2, lon2),
+ * the angular distance in degrees is returned.
+ */
+SC_SYSTEM_CORE_API
+double delta(double lat1, double lon1, double lat2, double lon2);
+
+/**
+ * For two points (lat1, lon1) and (lat2, lon2),
  * the angular distance 'dist' in degrees,
  * the azimuth 'azi1' (azimuth of point 2 seen from point 1) and
  * the azimuth 'azi2' (azimuth of point 1 seen from point 2)
@@ -43,7 +50,8 @@ namespace Geo
  */
 SC_SYSTEM_CORE_API
 void delazi(double lat1, double lon1, double lat2, double lon2,
-            double *out_dist, double *out_azi1, double *out_azi2);
+            double *out_dist = nullptr, double *out_azi1 = nullptr,
+            double *out_azi2 = nullptr);
 
 
 /**


### PR DESCRIPTION
This is a small improvements for the next API revision. This PR allows to pass null arguments to `Seiscomp::Math::Geo::delazi`: either one of `dist`, `azi` or `baz` can be omitted.

 That would make the code nicer in many places and it will also save some computations: the trigonometric functions can be expensive and sometimes are called millions of times.

