### PR TITLE
[filter] Adding recursive envelope filter

### DIFF
--- a/libs/seiscomp/math/filter/CMakeLists.txt
+++ b/libs/seiscomp/math/filter/CMakeLists.txt
@@ -14,6 +14,7 @@ SET(FILTER_SOURCES
 	rmhp.cpp
 	chainfilter.cpp
 	seismometers.cpp
+	bpenv.cpp
 )
 
 SET(FILTER_HEADERS
@@ -36,6 +37,7 @@ SET(FILTER_HEADERS
 	op2filter.h
 	op2filter.ipp
 	seismometers.h
+	bpenv.h
 )
 
 SC_SETUP_LIB_SUBDIR(FILTER)

--- a/libs/seiscomp/math/filter/bpenv.cpp
+++ b/libs/seiscomp/math/filter/bpenv.cpp
@@ -1,0 +1,161 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+
+#include <math.h>
+#include <seiscomp/math/filter/bpenv.h>
+
+namespace Seiscomp {
+namespace Math {
+namespace Filtering {
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+static void checkParameters(double centerFrequency, double bandwidthOctaves, int order) {
+	if ( centerFrequency <= 0.  )
+		throw Core::ValueException("Filter center frequency must be positive");
+	if ( bandwidthOctaves <= 0. )
+		throw Core::ValueException("Filter band width must be positive");
+	if ( order < 0 )
+		throw Core::ValueException("Filter order must be non-negative");
+	if ( order > 10 )
+		throw Core::ValueException("Filter order > 10 makes no sense");
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template <typename T>
+BandPassEnvelope<T>::BandPassEnvelope(double centerFrequency, double bandwidthOctaves, int order, double fsamp)
+: _centerFrequency(centerFrequency)
+, _bandwidthOctaves(bandwidthOctaves)
+, _order(order)
+, _samplingFrequency(0)
+, _K(0), _yp(0), _bp(nullptr), _afterReset(true)
+{
+	checkParameters(_centerFrequency, _bandwidthOctaves, _order);
+	setSamplingFrequency(fsamp);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template <typename T>
+void BandPassEnvelope<T>::reset() {
+	double q = std::sqrt(std::pow(2, _bandwidthOctaves));
+	double fmin = _centerFrequency/q;
+	double fmax = _centerFrequency*q;
+
+	_bp = new IIR::ButterworthBandpass<T>(_order, fmin, fmax, _samplingFrequency);
+
+	_K = 0.5*_samplingFrequency/(M_PI*_centerFrequency);
+	_K = _K*_K;
+
+	_yp = 0;
+
+	_afterReset = true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template <typename T>
+void BandPassEnvelope<T>::setSamplingFrequency(double fsamp) {
+	if ( _samplingFrequency == fsamp )
+		return;
+
+	_samplingFrequency = fsamp;
+
+	reset();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template <typename T>
+int BandPassEnvelope<T>::setParameters(int n, const double *params) {
+	switch ( n ) {
+	case 3:
+		_order = (int) params[2];
+	case 2:
+		_bandwidthOctaves = params[1];
+	case 1:
+		_centerFrequency = params[0];
+		break;
+	default:
+		return 3;
+	}
+
+	checkParameters(_centerFrequency, _bandwidthOctaves, _order);
+	reset();
+
+	return n;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template <typename T>
+InPlaceFilter<T>* BandPassEnvelope<T>::clone() const {
+	return new BandPassEnvelope<T>(
+		_centerFrequency, _bandwidthOctaves, _order, _samplingFrequency);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template <typename T>
+void BandPassEnvelope<T>::apply(int ndata, T *data) {
+	_bp->apply(ndata, data);
+
+	if ( _afterReset && ndata > 0 ) {
+		_yp = data[0];
+		_afterReset = false;
+	}
+
+	for ( int i = 0; i < ndata; i++ ) {
+		double y { data[i] };
+		double dy { y - _yp };
+		data[i] = std::sqrt(y*y + _K*dy*dy);
+		_yp = y;
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+INSTANTIATE_INPLACE_FILTER(BandPassEnvelope, SC_SYSTEM_CORE_API);
+REGISTER_INPLACE_FILTER(BandPassEnvelope, "BPENV");
+
+
+} // namespace Seiscomp::Math::Filtering
+} // namespace Seiscomp::Math
+} // namespace Seiscomp

--- a/libs/seiscomp/math/filter/bpenv.h
+++ b/libs/seiscomp/math/filter/bpenv.h
@@ -1,0 +1,99 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+
+#ifndef SEISCOMP_FILTERING_BPENV_H
+#define SEISCOMP_FILTERING_BPENV_H
+
+
+#include <seiscomp/math/filter.h>
+#include <seiscomp/math/filter/butterworth.h>
+
+
+namespace Seiscomp {
+namespace Math {
+namespace Filtering {
+
+// Band pass and envelope filter
+//
+// This is a recursive band pass and envelope filter combination. Strictly
+// speaking the envelope would require frequency-domain filtering because it
+// requires the Hilbert transform of the signal. We cannot compute the Hilbert
+// transform using time-domain recursive filters. By applying a rather narrow
+// band pass to the data, however, we can compute an approximate Hilbert
+// transform. This is because for a narrow-band signal the Hilbert transform
+// will be the scaled time derivative. This actually works quite well in
+// practice as long as the band pass is not too wide and has relatively steep
+// corners to block energy from outside the passband. A band width of one
+// octave and a filter order of four was found to work well in most cases.
+// It is therefore highly recommended to stick to these defaults and only set
+// the center frequency.
+//
+// This filter may be used in a filter chain. Its name is BPENV and it accepts
+// up to three arguments:
+//   - center frequency in Hz (must be specified)
+//   - bandwidth in octaves (default: 1)
+//   - filter order (default: 4)
+//
+// Author:
+//    Joachim Saul, GFZ Potsdam
+//    saul@gfz-potsdam.de
+
+
+template <typename T>
+class BandPassEnvelope : public InPlaceFilter<T> {
+	public:
+		BandPassEnvelope(double centerFrequency=1, double bandwidthOctaves=1, int order=4, double fsamp=0);
+
+		// Apply filter to data vector in place
+		void apply(int ndata, T *data) override;
+
+		// Apply a full reset
+		void reset();
+
+		// Set the sampling frequency in Hz. Allows delayed
+		// initialization when the data arrive.
+		void setSamplingFrequency(double fsamp) override;
+
+		int setParameters(int n, const double *params) override;
+
+		InPlaceFilter<T> *clone() const override;
+
+
+	private:
+		double _centerFrequency;
+		double _bandwidthOctaves;
+		int    _order;
+		double _samplingFrequency;
+		double _K, _yp;
+
+		using FilterPtr = typename Core::SmartPointer<Math::Filtering::InPlaceFilter<T>>::Impl;
+		FilterPtr _bp;
+
+		// Flag to indicate some pending initialization
+		bool _afterReset;
+};
+
+
+} // namespace Seiscomp::Math::Filtering
+} // namespace Seiscomp::Math
+} // namespace Seiscomp
+
+
+#endif


### PR DESCRIPTION
Band pass and envelope filter

This is a recursive band pass and envelope filter combination. Strictly speaking the envelope would require frequency-domain filtering because it requires the Hilbert transform of the signal. We cannot compute the _exact_ Hilbert transform using time-domain recursive filters. By applying a rather narrow band pass to the data, however, we can compute an _approximate_ Hilbert transform. This is because for a narrow-band signal the Hilbert transform will be the scaled time derivative. This actually works quite well in practice as long as the band pass is not too wide and has relatively steep corners to block energy from outside the pass band. A band width of one octave and a filter order of four was found to work well in most cases. It is therefore highly recommended to stick to these defaults and only set the center frequency.

This filter may be used in a filter chain. Its name is BPENV and it accepts
up to three arguments:
  - center frequency in Hz (must be specified)
  - bandwidth in octaves (default: 1)
  - filter order (default: 4)