### PR TITLE
Update global_gui.xml

### DIFF
--- a/apps/gui/descriptions/global_gui.xml
+++ b/apps/gui/descriptions/global_gui.xml
@@ -63,9 +63,9 @@
 						using the OpenStreetMap file structure is /path/to/maps/%l/%c/%r.png.
 					</description>
 				</parameter>
-				<parameter name="format" type="string" default="rectangular">
+				<parameter name="format" type="string" default="Rectangular">
 					<description>
-						Projection of the map tiles. Supported formats are: rectangular and mercator.
+						Projection of the map tiles. Supported formats are: Rectangular and Mercator.
 					</description>
 				</parameter>
 				<parameter name="cacheSize" type="int" unit="bytes" default="0">


### PR DESCRIPTION
The information in the description is misleading. It requires that projection names be "Rectangular" and "Mercator," otherwise it will throw an error as "Projection rectangular not available, defaulting to Rectangular"