### PR TITLE
[stdloc] revision of configuration parameters and their defaults

### DIFF
--- a/plugins/locator/stdloc/descriptions/global_stdloc.xml
+++ b/plugins/locator/stdloc/descriptions/global_stdloc.xml
@@ -17,7 +17,7 @@
 				<group name="profile">
 					<struct type="stdloc profile" link = "StdLoc.profiles">
 
-						<parameter name="method" type="string" default="GridSearch+LeastSquares">
+						<parameter name="method" type="string" default="LeastSquares" values="LeastSquares,GridSearch,OctTree,GridSearch+LeastSquares,OctTree+LeastSquares" >
 							<description>The location method to use: LeastSquares, GridSearch, OctTree,
 							 GridSearch+LeastSquares or OctTree+LeastSquares.
 							</description>
@@ -71,30 +71,35 @@
 						<group name="GridSearch">
 							<description>
 								Find the source location by evaluating the hypocenter probability
-								of each grid cell and returning the maximum likelihood hypocenter.
-								The source time is derived from the weighted average of arrival
+								of each grid point and returning the maximum likelihood hypocenter.
+								The source time is derived from the weighted average of the arrival
 								travel times.
 								The solution can be further improved combining it with the Least Squares
-								algorithm, which will then be run for each grid cell, using the cell
-								centroid as initial location estimate. In this case only few big cells
-								are required.
+								algorithm, which will then be run for each grid point, using it as
+								initial location estimate. In this case only few sparse points are
+								required.
 							</description>
-							<parameter name="center" type="list:string" default="auto,auto,5">
-								<description>Latitude,longitude,depth[km]. </description>
+							<parameter name="center" type="list:string" unit="deg,deg,km" default="auto,auto,20">
+								<description>Grid center defined as: latitude,longitude,depth. The
+								special value "auto" can be used and the corresponding latitude, longitude
+								 and/or depth will be automatically computed as the average of the arrival
+								station locations.
+								</description>
 							</parameter>
-							<parameter name="autoLatLon" type="boolean" default="true">
-								<description>If enabled, the grid center latitude and longitude
-								are automatically computed as the average of the arrival station
-								locations. The center depth should still be provided.
-							</description>
-							</parameter> 
-							<parameter name="size" type="list:string" unit="km" default="20,20,5">
-								<description>Grid X, Y, Z size in km</description>
+							<parameter name="size" type="list:string" unit="km" default="40,40,30">
+								<description>Grid size in km defined as: X,Y,Z direction extents around
+								the 'GridSearch.center', where X is the longitudinal extent, Y the
+								latitudinal extent and Z the vertical extent.
+								</description>
 							</parameter>
-							<parameter name="cellSize" type="list:string" unit="km" default="2.5,2.5,5">
-								<description>Cell X, Y, Z size in km</description>
+							<parameter name="numPoints" type="list:string" default="">
+								<description>Grid number of points in the X, Y, Z direction defined 
+								as: numX,numY,numZ. The first and last point will lie on the grid
+								boundary unless the number of points is 1 and the point will be
+								in the grid center.
+								</description>
 							</parameter>
-							<parameter name="misfitType" type="string" default="L1">
+							<parameter name="misfitType" type="string" default="L1" values="L1,L2" >
 								<description>The type of misfit to use, from which the likelyhood function is
 									derived: L1 or L2 norm. L1 is less sensitive to outliers and so more 
 									suitable with automatic picks, L2 is the preferred choice for manual picks.
@@ -114,7 +119,11 @@
 						<group name="OctTree">
 							<description>
 								Find the source location and time via OctTree search. This method uses the
-								parameters defined in GridSearch, but applies the OctTree search algorithm.
+								parameters defined in GridSearch, but applies the OctTree search algorithm
+								to the grid. The starting cells of the OctTree search are created by 
+								dividing the initial grid in equally sized cells. The number of cells in
+								each direction is 'GridSearch.numPoints' - 1, since the grid points
+								becomes the cell vertices.
 								The solution can be further improved combining OctTree with the Least Squares
 								algorithm, which can use the OctTree solution as initial location estimate.
 							</description>
@@ -139,6 +148,12 @@
 								available then this method should be combined with GridSearch or
 								OctTree.
 							</description>
+							<parameter name="depthInit" type="double" default="20">
+								<description>
+									The initial depth estimate, used only when method is 'LeastSquares'
+									and no initial location is provided.
+								</description>
+							</parameter>
 							<parameter name="iterations" type="int" default="20">
 								<description>
 									Number of iterations. Each iteration will use the

--- a/plugins/locator/stdloc/stdloc.h
+++ b/plugins/locator/stdloc/stdloc.h
@@ -161,6 +161,16 @@ class StdLoc : public Seiscomp::Seismology::LocatorInterface {
 		                        std::vector<double> &travelTimes, CovMtrx &covm,
 		                        bool computeCovMtrx) const;
 
+		void locateLeastSquares(const PickList &pickList,
+		                        const std::vector<double> &weights,
+		                        const std::vector<double> &sensorLat,
+		                        const std::vector<double> &sensorLon,
+		                        const std::vector<double> &sensorElev,
+		                        double &newLat, double &newLon, double &newDepth,
+		                        Seiscomp::Core::Time &newTime,
+		                        std::vector<double> &travelTimes, CovMtrx &covm,
+		                        bool computeCovMtrx) const;
+
 		void computeCovarianceMatrix(const std::vector<Cell> &cells,
 		                             const Cell &bestCell,
 		                             bool useExpectedHypocenter,
@@ -198,16 +208,18 @@ class StdLoc : public Seiscomp::Seismology::LocatorInterface {
 			double confLevel;
 
 			struct {
-				double autoLatLon;
 				double originLat;
 				double originLon;
 				double originDepth; // km
+				bool   autoOriginLat;
+				bool   autoOriginLon;
+				bool   autoOriginDepth;
 				double xExtent;     // km
 				double yExtent;     // km
 				double zExtent;     // km
-				double cellXExtent; // km
-				double cellYExtent; // km
-				double cellZExtent; // km
+				int    numXPoints;
+				int    numYPoints;
+				int    numZPoints;
 				std::string misfitType;
 				double travelTimeError;
 			} gridSearch;
@@ -218,6 +230,7 @@ class StdLoc : public Seiscomp::Seismology::LocatorInterface {
 			} octTree;
 
 			struct {
+				double depthInit;
 				int iterations;
 				double dampingFactor;
 				std::string solverType;


### PR DESCRIPTION
Dear @gempa-dirk,

 this is an update to the configuration parameters of `stdloc` as discussed by email, plus some minor changes.

1 - `GridSearch.cellSize` has been replaced by `GridSearch.numPoints`
2 - Removed default value of `GridSearch.numPoints` (former `GridSearch.cellSize`) to force the user to make a choice
3 - Removed `GridSearch.autoLatLon` and replaced by the special value `auto` in `GridSearch.center` 
4 - default method is now `LeastSquares` (so that is behaves as `LOCSAT` locator)
5 - added `LeastSquares.depthInit` (like `LOCSAT` locator)
6 - update some parameter descriptions

This is a trivial patch, since I didn't make any change in the math or in the logic of the code. However renaming the parameters can lead to annoying bugs. I tested the code myself, but not as much as I usually do. So I would like to kindly ask @gempa-dirk to run some tests on his own before merging this PR.

thanks,
Luca