### PR TITLE
Improvements to Flinn-Engdahl region names

### DIFF
--- a/libs/seiscomp/seismology/regions/fedata/names.asc
+++ b/libs/seiscomp/seismology/regions/fedata/names.asc
@@ -31,8 +31,8 @@ Off Coast of Oregon
 Near Coast of Oregon
 Oregon
 Western Idaho
-Off Coast of N. California
-Near Coast of N. California
+Off Coast of Northern California
+Near Coast of Northern California
 Northern California
 Nevada
 Off Coast of California
@@ -42,9 +42,9 @@ Southern Nevada
 Western Arizona
 Southern California
 California-Arizona Border Region
-Calif.-Baja Calif. Border Region
-W. Arizona-Sonora Border Region
-Off W Coast of Baja California
+California-Baja California Border Region
+Western Arizona-Sonora Border Region
+Off West Coast of Baja California
 Baja California, Mexico
 Gulf of California
 Sonora, Mexico
@@ -142,7 +142,7 @@ Cordoba Province, Argentina
 Uruguay
 Off Coast of Southern Chile
 Southern Chile
-S. Chile-Argentina Border Region
+South Chile-Argentina Border Region
 Southern Argentina
 Tierra Del Fuego
 Falkland Islands Region
@@ -155,15 +155,15 @@ South Shetland Islands
 Antarctic Peninsula
 Southwestern Atlantic Ocean
 Weddell Sea
-Off W. Coast of N. Island, N.Z.
+Off West Coast of North Island, New Zealand
 North Island, New Zealand
-Off E. Coast of N. Island, N.Z.
-Off W. Coast of S. Island, N.Z.
+Off East Coast of North Island, New Zealand
+Off West Coast of South Island, New Zealand
 South Island, New Zealand
 Cook Strait, New Zealand
-Off E. Coast of S. Island, N.Z.
+Off East Coast of South Island, New Zealand
 North of Macquarie Island
-Auckland Islands, N.Z. Region
+Auckland Islands, New Zealand Region
 Macquarie Island Region
 South of New Zealand
 Samoa Islands Region
@@ -187,26 +187,26 @@ Vanuatu Islands
 New Caledonia
 Loyalty Islands
 Southeast of Loyalty Islands
-New Ireland Region, P.N.G.
+New Ireland Region, Papua New Guinea
 North of Solomon Islands
-New Britain Region, P.N.G.
+New Britain Region, Papua New Guinea
 Solomon Islands
 D'Entrecasteaux Islands Region
 South of Solomon Islands
 West Papua Region, Indonesia
 Near North Coast of West Papua
-Ninigo Islands Region, P.N.G.
-Admiralty Islands Region, P.N.G.
-Near N. Coast of New Guinea, PNG.
+Ninigo Islands Region, Papua New Guinea
+Admiralty Islands Region, Papua New Guinea
+Near North Coast of New Guinea, Papua New Guinea
 West Papua, Indonesia
 New Guinea, Papua New Guinea
 Bismarck Sea
 Aru Islands Region, Indonesia
 Near South Coast of West Papua
-Near S. Coast of New Guinea, PNG.
-Eastern New Guinea Reg., P.N.G.
+Near South Coast of New Guinea, Papua New Guinea
+Eastern New Guinea Region, Papua New Guinea
 Arafura Sea
-W. Caroline Islands, Micronesia
+Western Caroline Islands, Micronesia
 South of Mariana Islands
 Southeast of Honshu, Japan
 Bonin Islands, Japan Region
@@ -227,10 +227,10 @@ Near West Coast of Honshu, Japan
 Eastern Honshu, Japan
 Near East Coast of Honshu, Japan
 Off East Coast of Honshu, Japan
-Near S. Coast of Honshu, Japan
+Near South Coast of Honshu, Japan
 South Korea
 Western Honshu, Japan
-Near S. Coast of Western Honshu
+Near South Coast of Western Honshu
 Northwest of Ryukyu Islands
 Kyushu, Japan
 Shikoku, Japan
@@ -278,7 +278,7 @@ Java, Indonesia
 Bali Sea
 Flores Sea
 Banda Sea
-Tanimbar Islands Reg., Indonesia
+Tanimbar Islands Region, Indonesia
 South of Java, Indonesia
 Bali Region, Indonesia
 South of Bali, Indonesia
@@ -302,7 +302,7 @@ South China Sea
 Eastern Kashmir
 Kashmir-India Border Region
 Kashmir-Xizang Border Region
-Western-Xizang India Border Reg.
+Western-Xizang India Border Region
 Xizang
 Sichuan, China
 Northern India
@@ -310,14 +310,14 @@ Nepal-India Border Region
 Nepal
 Sikkim, India
 Bhutan
-Eastern Xizang-India Border Reg.
+Eastern Xizang-India Border Region
 Southern India
 India-Bangladesh Border Region
 Bangladesh
 Northeastern India
 Yunnan, China
 Bay of Bengal
-Kyrgyzstan-Xinjiang Border Reg.
+Kyrgyzstan-Xinjiang Border Region
 Southern Xinjiang, China
 Gansu, China
 Western Nei Mongol, China
@@ -328,7 +328,7 @@ Lake Baykal Region, Russia
 East of Lake Baykal, Russia
 Eastern Kazakhstan
 Lake Issyk Kul Region
-Kazakhstan-Xinjiang Border Reg.
+Kazakhstan-Xinjiang Border Region
 Northern Xinjiang, China
 Russia-Mongolia Border Region
 Mongolia
@@ -339,9 +339,9 @@ Caspian Sea
 Northwestern Uzbekistan
 Turkmenistan
 Turkmenistan-Iran Border Region
-Turkmenistan-Afghanistan Border Reg.
+Turkmenistan-Afghanistan Border Region
 Turkey-Iran Border Region
-Armenia-Azerbaijan-Iran Border Reg.
+Armenia-Azerbaijan-Iran Border Region
 Northwestern Iran
 Iran-Iraq Border Region
 Western Iran
@@ -354,7 +354,7 @@ Southern Iran
 Southwestern Pakistan
 Gulf of Oman
 Off Coast of Pakistan
-Ukraine/Moldova/SW Russia Region
+Ukraine/Moldova/Southwest Russia Region
 Romania
 Bulgaria
 Black Sea
@@ -364,7 +364,7 @@ Greece Bulgaria Border Region
 Greece
 Aegean Sea
 Turkey
-Georgia Armenia Turkey Border Reg.
+Georgia Armenia Turkey Border Region
 Southern Greece
 Dodecanese Islands, Greece
 Crete, Greece
@@ -380,7 +380,7 @@ Near South Coast of France
 Corsica, France
 Central Italy
 Adriatic Sea
-NW Balkan Region
+Northwest Balkan Region
 West of Gibraltar
 Strait of Gibraltar
 Balearic Islands, Spain
@@ -513,8 +513,8 @@ North Carolina
 Off East Coast of United States
 Florida Peninsula
 Bahama Islands
-E. Arizona-Sonora Border Region
-New Mexico-Chihuahua Border Reg.
+Eastern Arizona-Sonora Border Region
+New Mexico-Chihuahua Border Region
 Texas-Mexico Border Region
 Southern Texas
 Near Coast of Texas
@@ -558,7 +558,7 @@ Sudan
 Ethiopia
 Western Gulf of Aden
 Northwestern Somalia
-Off S. Coast of Northwest Africa
+Off South Coast of Northwest Africa
 Cameroon
 Equatorial Guinea
 Central African Republic
@@ -600,7 +600,7 @@ Off South Coast of Australia
 Near Coast of South Australia
 New South Wales, Australia
 Victoria, Australia
-Near SE Coast of Australia
+Near Southeast Coast of Australia
 Near East Coast of Australia
 East of Australia
 Norfolk Island, Australia Region
@@ -611,10 +611,10 @@ Southeast of Australia
 North Pacific Ocean
 Hawaiian Islands Region
 Hawaii
-E. Caroline Islands, Micronesia
+Eastern Caroline Islands, Micronesia
 Marshall Islands Region
-Enewetak Atoll Reg, Marshall Islands
-Bikini Atoll Reg., Marshall Islands
+Enewetak Atoll Region, Marshall Islands
+Bikini Atoll Region, Marshall Islands
 Gilbert Islands, Kiribati Region
 Johnston Island Region
 Line Islands, Kiribati Region
@@ -654,7 +654,7 @@ Near Coast of Central Siberia, Russia
 East of Severnaya Zemlya
 Laptev Sea
 Southeastern Siberia, Russia
-E Russia-NE China Border Region
+Eastern Russia-Northeastern China Border Region
 Northeastern China
 North Korea
 Sea of Japan
@@ -671,12 +671,12 @@ Near Northern Coast of Eastern Siberia
 Eastern Siberia, Russia
 Chukchi Sea
 Bering Strait
-St. Lawrence Island, Alaska Reg.
+St. Lawrence Island, Alaska Region
 Beaufort Sea
 Northern Alaska
 Northern Yukon Territory, Canada
 Queen Elizabeth Islands, Canada
-NW Territories - Nunavut, Canada
+Northwest Territories - Nunavut, Canada
 Western Greenland
 Baffin Bay
 Baffin Island Region, Canada
@@ -685,8 +685,8 @@ Southern East Pacific Rise
 Easter Island Region
 West Chile Rise
 Juan Fernandez Islands Region
-East of North Island, N.Z.
-Chatham Islands, N.Z. Region
+East of North Island, New Zealand
+Chatham Islands, New Zealand Region
 South of Chatham Islands
 Pacific Antarctic Ridge
 Southern Pacific Ocean
@@ -721,7 +721,7 @@ Northwestern Kashmir
 Finland
 Norway-Russia Border Region
 Finland-Russia Border Region
-Baltics/Belarus/Northwestern Russia Reg.
+Baltics/Belarus/Northwestern Russia Region
 Northwestern Siberia, Russia
 Northcentral Siberia, Russia
 Victoria Land, Antarctica
@@ -743,7 +743,7 @@ Western Indian Antarctic Ridge
 Western Sahara
 Mauritania
 Mali
-Sengal-Gambia Region
+Senegal-Gambia Region
 Guinea Region
 Sierra Leone
 Liberia Region


### PR DESCRIPTION
The important thing here is that Senegal is spelled "Sengal", which is incorrect.

Additionally, since I could find no other French translation elsewhere (https://en.wikipedia.org/wiki/Flinn-Engdahl_regionalization only has translations to Spanish and German the same languages other than English supported by https://github.com/jsaul/flinnengdahl), I did my own translation to French. In the process, I found that the (inconsistent!) use of abbreviations really got in the way, so here I've also eliminated the abbreviations.

If there is a reason to keep the abbreviations, let me know and I'll initiate a pull request that only corrects the spelling of Senegal.