### PR TITLE
[ttt/homogeneous] Try to read application configuration first

### DIFF
--- a/libs/seiscomp/seismology/ttt/homogeneous.cpp
+++ b/libs/seiscomp/seismology/ttt/homogeneous.cpp
@@ -19,6 +19,7 @@
 
 
 
+#include <seiscomp/system/application.h>
 #include <seiscomp/seismology/ttt.h>
 #include <seiscomp/core/strings.h>
 #include <seiscomp/math/geo.h>
@@ -117,22 +118,33 @@ double computeDistance(double lat1, double lon1,
 bool Homogeneous::setModel(const string &model) {
 
 	// load global configuration
-	Config::Config cfg;
-	if ( ! Environment::Instance()->initConfig(&cfg, "") ) {
-		return false;
+	auto app = Seiscomp::System::Application::Instance();
+	const Config::Config *cfg;
+	Config::Config tmp;
+
+	if ( app ) {
+		cfg = &app->configuration();
+	}
+	else {
+		if ( !Environment::Instance()->initConfig(&tmp, "") ) {
+			return false;
+		}
+		else {
+			cfg = &tmp;
+		}
 	}
 
 	string base = "ttt.homogeneous." + model + ".";
 	vector<string> origin;
 	try {
-		_pVel      = cfg.getDouble(base + "P-velocity");
-		_sVel      = cfg.getDouble(base + "S-velocity");
-		_radius    = cfg.getDouble(base + "radius");
-		_minDepth  = cfg.getDouble(base + "minDepth");
-		_maxDepth  = cfg.getDouble(base + "maxDepth");
-		origin = cfg.getStrings(base + "origin");
+		_pVel      = cfg->getDouble(base + "P-velocity");
+		_sVel      = cfg->getDouble(base + "S-velocity");
+		_radius    = cfg->getDouble(base + "radius");
+		_minDepth  = cfg->getDouble(base + "minDepth");
+		_maxDepth  = cfg->getDouble(base + "maxDepth");
+		origin = cfg->getStrings(base + "origin");
 	}
-	catch (...) {
+	catch ( ... ) {
 		return false;
 	}
 


### PR DESCRIPTION
Currently the homogeneous was reading its parameters exclusively from global.cfg at all three configuration stages. This makes it impossible to configure it per application, e.g. in app.cfg.