### PR TITLE
[gui] Add time confidence to picker marker tooltip

### DIFF
--- a/libs/seiscomp/gui/datamodel/pickerview.cpp
+++ b/libs/seiscomp/gui/datamodel/pickerview.cpp
@@ -983,6 +983,11 @@ class PickerMarker : public RecordMarker {
 			catch ( ... ) {}
 			if ( !_referencedPick->methodID().empty() )
 				text += QString("\nmethod: %1").arg(_referencedPick->methodID().c_str());
+			try {
+				double confidence = _referencedPick->time().confidenceLevel();
+				text += QString("\nconfidence: %1").arg(confidence);
+			}
+			catch ( ... ) {}
 			if ( !_referencedPick->filterID().empty() )
 				text += QString("\nfilter: %1").arg(_referencedPick->filterID().c_str());
 			try {


### PR DESCRIPTION
This allows the [pick time confidence level](https://www.seiscomp.de/doc/base/api-python.html#seiscomp.datamodel.TimeQuantity.confidenceLevel) to be shown in the tooltip of the picker window in `scolv`. It is useful with automatic pickers providing confidence level, e.g., based on machine learning.