### PR TITLE
[gui] increase distance filtering precision to 1 digital point

### DIFF
--- a/libs/seiscomp/gui/datamodel/amplitudeview.cpp
+++ b/libs/seiscomp/gui/datamodel/amplitudeview.cpp
@@ -2129,7 +2129,7 @@ void AmplitudeView::init() {
 
 	if ( SCScheme.unit.distanceInKM ) {
 		SC_D.spinDistance->setRange(0, 25000);
-		SC_D.spinDistance->setDecimals(0);
+		SC_D.spinDistance->setDecimals(1);
 		SC_D.spinDistance->setSuffix("km");
 	}
 	else {

--- a/libs/seiscomp/gui/datamodel/pickerview.cpp
+++ b/libs/seiscomp/gui/datamodel/pickerview.cpp
@@ -2871,7 +2871,7 @@ void PickerView::init() {
 
 	if ( SCScheme.unit.distanceInKM ) {
 		SC_D.spinDistance->setRange(0, 25000);
-		SC_D.spinDistance->setDecimals(0);
+		SC_D.spinDistance->setDecimals(1);
 		SC_D.spinDistance->setSuffix("km");
 	}
 	else {


### PR DESCRIPTION
Dear developers,

I would like to increase the distance filtering precision  in the `PickerView` and `AmplitudeView`.  Now that we can use  the hypocenter distance in these GUIs I have started paying attention to this detail and the current `SpinBox` precision doesn't allow for decimal points. So, if this doesn't affect other use cases, I would like to allow at least 1 decimal point.

thanks
Luca