### PR TITLE
[stdloc] set enableConfidenceEllipsoid to false by default

### DIFF
--- a/plugins/locator/stdloc/descriptions/global_stdloc.xml
+++ b/plugins/locator/stdloc/descriptions/global_stdloc.xml
@@ -61,7 +61,7 @@
 							Confidence level, between 0.5 and 1.0, used in computing the confidence ellipsoid.
 							</description>
 						</parameter>
-						<parameter name="enableConfidenceEllipsoid" type="boolean" default="true">
+						<parameter name="enableConfidenceEllipsoid" type="boolean" default="false">
 							<description>
 							Compute the confidence ellipsoid for the location. This is optional since
 							if it is not required it can be disabled to save some computation.

--- a/plugins/locator/stdloc/stdloc.cpp
+++ b/plugins/locator/stdloc/stdloc.cpp
@@ -307,7 +307,7 @@ bool StdLoc::init(const Config::Config &config) {
 	defaultProf.usePickUncertainties = false;
 	defaultProf.pickUncertaintyClasses = {0.000, 0.025, 0.050,
 	                                      0.100, 0.200, 0.400};
-	defaultProf.enableConfidenceEllipsoid = true;
+	defaultProf.enableConfidenceEllipsoid = false;
 	defaultProf.confLevel = 0.9;
 	defaultProf.gridSearch.originLat = 0.;
 	defaultProf.gridSearch.originLon = 0.;


### PR DESCRIPTION
Despite my efforts to fix the eigv/chi2 code, I still see random crashes (it happened only one, but I was not able to reproduce it). That library is a nightmare so I do not trust that code very much and I would like to disable the computation of the confidence ellipsoid by default.

The common usage of `stdloc` is to be used by `scanloc` and in this case the confidence ellipsoid is not required.

If that code crashes when called from scolv that is annoying, but the user notices the issue. However, If the code crashes when called by scanloc than who is going to notice that?

