### PR TITLE
[stdloc] disable OctTree grid boundary check if OctTree+LeastSquares

### DIFF
--- a/plugins/locator/stdloc/stdloc.cpp
+++ b/plugins/locator/stdloc/stdloc.cpp
@@ -994,6 +994,7 @@ Origin *StdLoc::locate(PickList &pickList) {
 		              (computeCovMtrx &&
 		               _currentProfile.method == Profile::Method::OctTree));
 		if ( _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+			_rejectLocation = false; // skip OctTree check of grid boundary
 			locateLeastSquares(pickList, weights, sensorLat, sensorLon,
 			                   sensorElev, originLat, originLon, originDepth,
 			                   originTime, originLat, originLon, originDepth,
@@ -1058,6 +1059,7 @@ Origin *StdLoc::locate(PickList &pickList, double initLat, double initLon,
 		              (computeCovMtrx &&
 		               _currentProfile.method == Profile::Method::OctTree));
 		if ( _currentProfile.method == Profile::Method::OctTreeAndLsqr ) {
+			_rejectLocation = false; // skip OctTree check of grid boundary
 			locateLeastSquares(pickList, weights, sensorLat, sensorLon,
 			                   sensorElev, originLat, originLon, originDepth,
 			                   originTime, originLat, originLon, originDepth,


### PR DESCRIPTION
This is a minor thing, but with the  `OctTree+LeastSquares` method it makes sense to find the `LeastSquares` solution even if the `OctTree`  solution is on the grid boundary, because it is very likely that the user select a coarse grid and the solution most certainly lays on the cell close to the boundary.