### PR TITLE
[stdloc] fix phase name detection

### DIFF
--- a/plugins/locator/stdloc/stdloc.cpp
+++ b/plugins/locator/stdloc/stdloc.cpp
@@ -33,6 +33,7 @@
 #include <seiscomp/math/mean.h>
 #include <seiscomp/seismology/locatorinterface.h>
 #include <seiscomp/seismology/ttt.h>
+#include <seiscomp/utils/misc.h>
 
 #include <algorithm>
 #include <cmath>
@@ -1329,10 +1330,10 @@ bool StdLoc::computeOriginTime(const PickList &pickList,
 		try {
 			const char *phaseName = pick->phaseHint().code().c_str();
 			if ( _currentProfile.PSTableOnly ) {
-				if ( *pick->phaseHint().code().begin() == 'P' ) {
+				if ( Util::getShortPhaseName(pick->phaseHint().code()) == 'P' ) {
 					phaseName = "P";
 				}
-				else if ( *pick->phaseHint().code().begin() == 'S' ) {
+				else if ( Util::getShortPhaseName(pick->phaseHint().code()) == 'S' ) {
 					phaseName = "S";
 				}
 			}


### PR DESCRIPTION
This PR fixes the error reported by @gempa-dirk via email.

----

However I still believe the parameter `PSTableOnly` needs a discussion( @gempa-jabe & @gempa-dirk).

In my opinion the phase label assigned by the user (e.g. 'Pg', 'Pn' etc) should be passed to the `TravelTimeTable`  implementation without modification when `stdloc` calls `ttt::compute(...)` or `ttt:::computeTime(...)`.

However, in practice, the travel time table (both `LOCSAT` and `libtau`) sometimes disagree  with the phase label assigned by the user. This can happen because the user may know better the local geology than a generic velocity model and so `stdloc` needs to convert the ttt query from a specific phase to a generic `P` or `S` to avoid a failure.  In a different case a user may use TauP Toolkit to properly generate the ttt for a region and in that case they may want to disable the `PSTableOnly` parameter. 

To cover both scenarios I created the `PSTableOnly` parameter in `StdLoc`. However if feels a bit cheap and if you have better ideas I would be happy to hear about it. 
