### PR TITLE
[scolv] Display Pick Comments in  Pickerview Tooltip

### DIFF
--- a/libs/seiscomp/gui/datamodel/pickerview.cpp
+++ b/libs/seiscomp/gui/datamodel/pickerview.cpp
@@ -991,7 +991,7 @@ class PickerMarker : public RecordMarker {
 				text += QString("\nmethod: %1").arg(_referencedPick->methodID().c_str());
 			try {
 				double confidence = _referencedPick->time().confidenceLevel();
-				text += QString("\nconfidence: %1").arg(confidence);
+				text += QString("\ntime confidence: %1").arg(confidence);
 			}
 			catch ( ... ) {}
 			if ( !_referencedPick->filterID().empty() )
@@ -1006,6 +1006,13 @@ class PickerMarker : public RecordMarker {
 				text += QString("\nhoriz. slowness: %1 deg/s").arg(hs);
 			}
 			catch ( ... ) {}
+			for (size_t i = 0; i < _referencedPick->commentCount(); ++i) {
+				Seiscomp::DataModel::Comment *comment = _referencedPick->comment(i);
+				if (!comment) continue;
+
+				text += QString("\ncomment %1: ").arg(comment->id().c_str());
+				text += QString("%1").arg(comment->text().c_str());
+			}
 
 			text += QString("\narrival: %1").arg(isArrival()?"yes":"no");
 
@@ -4574,6 +4581,7 @@ void PickerView::addArrival(Seiscomp::Gui::RecordWidget* widget,
 		                                        arrival->phase().code().c_str(),
 		                                        PickerMarker::Arrival, false);
 
+		SC_D.reader->loadComments(pick);
 		marker->setPick(pick);
 		marker->setId(id);
 


### PR DESCRIPTION
Here's another contribution to the tooltip!

# Changes:
- Added all pick comments (format "ID : value") to the tooltip.
- Ensured comments are loaded before assigning the pick.

# Implementation:
- PickerMarker: Iterates over commentCount(), appending comments to the tooltip.
- PickerView: Calls loadComments(pick) before setting it in marker.

# Example:
<img width="944" alt="Screenshot 2025-02-05 at 19 34 47" src="https://github.com/user-attachments/assets/e504bbfb-38a3-469b-8f0b-63b69a1bf41a" />

# Test version:
```bash
scolv
Framework: 7.0.0 Development
API version: 17.0.0
Data schema version: 0.13
GIT HEAD: 836f199e
Compiler: c++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Build system: Linux 5.15.0-117-generic
OS: Ubuntu 22.04.5 LTS / Linux
```