### PR TITLE
fix compile issue against latest libxml2

### DIFF
--- a/libs/seiscomp/io/archive/xmlarchive.cpp
+++ b/libs/seiscomp/io/archive/xmlarchive.cpp
@@ -484,7 +484,8 @@ void XMLArchive::close() {
 
 	_forceWriteVersion = -1;
 
-	initGenericErrorDefaultFunc(nullptr);
+        xmlStructuredErrorFunc handler = xmlStructuredErrorHandler;
+	 xmlStructuredErrorFunc(nullptr, handler);
 	setVersion(Core::Version(0,0));
 }
 


### PR DESCRIPTION
This PR serves to fix an error when compiling against the latest libxml2 > 2.14.
