### PR TITLE
[common] Extend City<T> with country, AdminRegion and type; enrich cities.xml

### DIFF
--- a/libs/seiscomp/gui/datamodel/eventlistview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventlistview.cpp
@@ -3890,7 +3890,6 @@ void EventListView::setEventModificationsEnabled(bool e) {
 
 
 
-
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 void EventListView::initTree() {
 	SC_D._treeWidget->clear();

--- a/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
@@ -771,6 +771,17 @@ void EventSummaryView::init() {
 	QRectF displayRect;
 	displayRect.setRect(lonmin, latmin, lonmax-lonmin, latmax-latmin);
 
+	// Store bounds for reuse when recentering on an event, so that
+	// display.lonmin/max/latmin/max are honoured beyond initial startup.
+	// Takes priority over display.defaultEventRadius.
+	bool hasCustomBounds = lonmin != -180 || lonmax != 180 || latmin != -90 || latmax != 90;
+	_displayRect = hasCustomBounds ? displayRect : QRectF();
+
+	// Configurable event radius (like olv.map.event.defaultRadius in scolv).
+	// Only used when no custom bounds are set.
+	try { _defaultEventRadius = SCApp->configGetDouble("display.defaultEventRadius"); }
+	catch ( ... ) { _defaultEventRadius = -1; }
+
 	_uiHypocenter->labelVDistance->setText(QString());
 	_uiHypocenter->labelVDistanceAutomatic->setText(QString());
 	_uiHypocenter->labelFrameInfoSpacer->setText(QString());
@@ -2384,10 +2395,16 @@ void EventSummaryView::updateMap(bool realignView){
 	_map->setOrigin(_currentOrigin.get());
 
 	if ( _currentOrigin && realignView ) {
-		if ( _recenterMap && _recenterMapConfig ) {
-			double radius = 30;
-			try { radius = std::min(radius, _currentOrigin->quality().maximumDistance()+0.1); }
-			catch ( ... ) {}
+		if ( !_displayRect.isNull() ) {
+			// Anchored region: always show the configured bounds
+			_map->canvas().displayRect(_displayRect);
+		}
+		else if ( _recenterMap && _recenterMapConfig ) {
+			double radius = _defaultEventRadius > 0 ? _defaultEventRadius : 30;
+			if ( _defaultEventRadius <= 0 ) {
+				try { radius = std::min(radius, _currentOrigin->quality().maximumDistance()+0.1); }
+				catch ( ... ) {}
+			}
 			_map->canvas().displayRect(QRectF(_currentOrigin->longitude()-radius, _currentOrigin->latitude()-radius, radius*2, radius*2));
 		}
 		else {

--- a/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
@@ -772,7 +772,7 @@ void EventSummaryView::init() {
 	displayRect.setRect(lonmin, latmin, lonmax-lonmin, latmax-latmin);
 
 	// Store bounds for reuse when recentering on an event, so that
-	// display.lonmin/max/latmin/max are honoured beyond initial startup.
+	// display.lonmin/max/latmin/max are honored beyond initial startup.
 	// Takes priority over display.defaultEventRadius.
 	bool hasCustomBounds = lonmin != -180 || lonmax != 180 || latmin != -90 || latmax != 90;
 	_displayRect = hasCustomBounds ? displayRect : QRectF();

--- a/libs/seiscomp/gui/datamodel/eventsummaryview.h
+++ b/libs/seiscomp/gui/datamodel/eventsummaryview.h
@@ -297,9 +297,11 @@ class SC_GUI_API EventSummaryView : public QWidget
 		bool _interactive;
 		bool _autoSelect;
 		bool _displayFocMechs;
-		bool _recenterMap;
-		bool _recenterMapConfig;
-		bool _ignoreOtherEvents;
+		bool   _recenterMap;
+		bool   _recenterMapConfig;
+		bool   _ignoreOtherEvents;
+		QRectF _displayRect;
+		double _defaultEventRadius{-1};
 		bool _showLastAutomaticSolution;
 		bool _showOnlyMostRecentEvent;
 		bool _enableFullTensor;

--- a/libs/seiscomp/math/coord.cpp
+++ b/libs/seiscomp/math/coord.cpp
@@ -283,7 +283,7 @@ const std::string &City<T>::category() const {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
-void City<T>::setType(const std::string &t) {
+void City<T>::setType(CityType t) {
 	_type = t;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -293,7 +293,7 @@ void City<T>::setType(const std::string &t) {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
-const std::string &City<T>::type() const {
+CityType City<T>::type() const {
 	return _type;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/libs/seiscomp/math/coord.cpp
+++ b/libs/seiscomp/math/coord.cpp
@@ -251,10 +251,73 @@ const std::string &City<T>::category() const {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
+void City<T>::setType(const std::string &t) {
+	_type = t;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
+const std::string &City<T>::type() const {
+	return _type;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
+void City<T>::setState(const std::string &s) {
+	_state = s;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
+const std::string &City<T>::state() const {
+	return _state;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
+void City<T>::setStateFull(const std::string &s) {
+	_stateFull = s;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
+const std::string &City<T>::stateFull() const {
+	return _stateFull;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
 void City<T>::serialize(Core::BaseObject::Archive& ar) {
 	NamedCoord<T>::serialize(ar);
 	ar & NAMED_OBJECT("countryID", _countryID);
 	ar & NAMED_OBJECT("category", _category);
+	ar & NAMED_OBJECT("type", _type);
+	ar & NAMED_OBJECT("state", _state);
+	ar & NAMED_OBJECT("stateFull", _stateFull);
 	ar & NAMED_OBJECT_HINT("population", _population, Core::BaseObject::Archive::XML_ELEMENT);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/libs/seiscomp/math/coord.cpp
+++ b/libs/seiscomp/math/coord.cpp
@@ -82,6 +82,18 @@ void Coord<T>::serialize(Archive& ar) {
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
+// AdminRegion implementation
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void AdminRegion::serialize(Core::BaseObject::Archive& ar) {
+	abbr = ""; name = "";
+	ar & NAMED_OBJECT("abbr", abbr);
+	ar & NAMED_OBJECT_HINT("name", name, Core::BaseObject::Archive::XML_ELEMENT);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
 // NamedCoord<T> implementation
 
 
@@ -231,6 +243,26 @@ const std::string &City<T>::countryID() const {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
+void City<T>::setCountry(const std::string &c) {
+	_country = c;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
+const std::string &City<T>::country() const {
+	return _country;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+template<typename T>
 void City<T>::setCategory(std::string &c) {
 	_category = c;
 }
@@ -271,8 +303,8 @@ const std::string &City<T>::type() const {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
-void City<T>::setState(const std::string &s) {
-	_state = s;
+void City<T>::setAdminRegion(const AdminRegion &r) {
+	_adminRegion = r;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -281,28 +313,8 @@ void City<T>::setState(const std::string &s) {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
-const std::string &City<T>::state() const {
-	return _state;
-}
-// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-
-
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-template<typename T>
-void City<T>::setStateFull(const std::string &s) {
-	_stateFull = s;
-}
-// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-
-
-
-// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-template<typename T>
-const std::string &City<T>::stateFull() const {
-	return _stateFull;
+const AdminRegion &City<T>::adminRegion() const {
+	return _adminRegion;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -316,8 +328,8 @@ void City<T>::serialize(Core::BaseObject::Archive& ar) {
 	ar & NAMED_OBJECT("countryID", _countryID);
 	ar & NAMED_OBJECT("category", _category);
 	ar & NAMED_OBJECT("type", _type);
-	ar & NAMED_OBJECT("state", _state);
-	ar & NAMED_OBJECT("stateFull", _stateFull);
+	ar & NAMED_OBJECT_HINT("country", _country, Core::BaseObject::Archive::XML_ELEMENT);
+	ar & NAMED_OBJECT_HINT("state", _adminRegion, Core::BaseObject::Archive::XML_ELEMENT);
 	ar & NAMED_OBJECT_HINT("population", _population, Core::BaseObject::Archive::XML_ELEMENT);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/libs/seiscomp/math/coord.cpp
+++ b/libs/seiscomp/math/coord.cpp
@@ -293,7 +293,7 @@ void City<T>::setType(CityType t) {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
 CityType City<T>::type() const {
-	return _type;
+	return _type.value_or(CityType{});
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -313,7 +313,8 @@ void City<T>::setAdminRegion(const AdminRegion &r) {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 template<typename T>
 const AdminRegion &City<T>::adminRegion() const {
-	return _adminRegion;
+	static const AdminRegion empty{};
+	return _adminRegion ? *_adminRegion : empty;
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/libs/seiscomp/math/coord.cpp
+++ b/libs/seiscomp/math/coord.cpp
@@ -87,7 +87,6 @@ void Coord<T>::serialize(Archive& ar) {
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 void AdminRegion::serialize(Core::BaseObject::Archive& ar) {
-	abbr = ""; name = "";
 	ar & NAMED_OBJECT("abbr", abbr);
 	ar & NAMED_OBJECT_HINT("name", name, Core::BaseObject::Archive::XML_ELEMENT);
 }

--- a/libs/seiscomp/math/coord.h
+++ b/libs/seiscomp/math/coord.h
@@ -22,6 +22,7 @@
 #define SEISCOMP_MATH_GEO_COORD_H
 
 #include <seiscomp/core/baseobject.h>
+#include <seiscomp/core/enumeration.h>
 #include <string>
 
 
@@ -82,6 +83,29 @@ typedef NamedCoord<double> NamedCoordD;
 
 
 /**
+ * Location type of a city derived from GeoNames feature codes.
+ * Serializes as a lowercase string attribute in XML.
+ */
+MAKEENUM(
+	CityType,
+	EVALUES(
+		CITYTYPE_UNKNOWN, //!< Absent or unrecognised type attribute
+		CITYTYPE_CITY,    //!< Capital or administrative centre (PPLC, PPLA, PPLA2)
+		CITYTYPE_TOWN,    //!< Populated place or minor admin centre (PPL, PPLA3, PPLA4)
+		CITYTYPE_VILLAGE, //!< Small settlement (PPLF, PPLL, PPLR, PPLS, etc.)
+		CITYTYPE_SUBURB   //!< Section of a populated place (PPLX)
+	),
+	ENAMES(
+		"",
+		"city",
+		"town",
+		"village",
+		"suburb"
+	)
+);
+
+
+/**
  * @brief Administrative region (state, province, etc.) associated with a city.
  *
  * Serializes as an XML child element carrying an optional abbreviation
@@ -131,17 +155,8 @@ class City : public NamedCoord<T> {
 		void setCategory(std::string &);
 		const std::string &category() const;
 
-		/**
-		 * @brief Location type derived from GeoNames feature codes.
-		 *
-		 * One of the following values (or empty if unknown):
-		 *   "city"    — capital or administrative centre (PPLC, PPLA, PPLA2)
-		 *   "town"    — populated place or minor admin centre (PPL, PPLA3, PPLA4)
-		 *   "village" — small settlement (PPLF, PPLL, PPLR, PPLS, etc.)
-		 *   "suburb"  — section of a populated place (PPLX)
-		 */
-		void setType(const std::string &);
-		const std::string &type() const;
+		void setType(CityType);
+		CityType type() const;
 
 		/**
 		 * @brief Administrative region (state/province).
@@ -163,7 +178,7 @@ class City : public NamedCoord<T> {
 		std::string _country;
 		double _population;
 		std::string _category;
-		std::string _type;
+		CityType _type;
 		AdminRegion _adminRegion;
 };
 

--- a/libs/seiscomp/math/coord.h
+++ b/libs/seiscomp/math/coord.h
@@ -104,12 +104,27 @@ class City : public NamedCoord<T> {
 		void setCategory(std::string &);
 		const std::string &category() const;
 
+		//! Location type, e.g. "city", "town", "village" (GeoNames feature code)
+		void setType(const std::string &);
+		const std::string &type() const;
+
+		//! Administrative region abbreviation, e.g. "NSW"
+		void setState(const std::string &);
+		const std::string &state() const;
+
+		//! Full administrative region name, e.g. "New South Wales"
+		void setStateFull(const std::string &);
+		const std::string &stateFull() const;
+
 		void serialize(Core::BaseObject::Archive& ar) override;
 
 	private:
 		std::string _countryID;
 		double _population;
 		std::string _category;
+		std::string _type;
+		std::string _state;
+		std::string _stateFull;
 };
 
 

--- a/libs/seiscomp/math/coord.h
+++ b/libs/seiscomp/math/coord.h
@@ -81,6 +81,29 @@ typedef NamedCoord<float> NamedCoordF;
 typedef NamedCoord<double> NamedCoordD;
 
 
+/**
+ * @brief Administrative region (state, province, etc.) associated with a city.
+ *
+ * Serializes as an XML child element carrying an optional abbreviation
+ * attribute and the full name as element text, e.g.:
+ * @code
+ *   <state abbr="NSW">New South Wales</state>
+ * @endcode
+ *
+ * The @c abbr field holds the ISO 3166-2 subdivision suffix (alphabetic
+ * portion only, e.g. "NSW" from "AU-NSW", "CA" from "US-CA"). It is left
+ * empty for subdivisions that use numeric codes or where no ISO code exists.
+ */
+struct SC_SYSTEM_CORE_API AdminRegion : public Core::BaseObject {
+	DECLARE_SERIALIZATION;
+
+	std::string abbr; //!< ISO 3166-2 suffix, e.g. "NSW", "CA" (may be empty)
+	std::string name; //!< Full region name, e.g. "New South Wales"
+
+	bool empty() const { return name.empty(); }
+};
+
+
 template<typename T>
 class City : public NamedCoord<T> {
 	public:
@@ -101,30 +124,47 @@ class City : public NamedCoord<T> {
 		void setCountryID(const std::string &);
 		const std::string &countryID() const;
 
+		//! Full country name, e.g. "Australia". Serializes as <country> child element.
+		void setCountry(const std::string &);
+		const std::string &country() const;
+
 		void setCategory(std::string &);
 		const std::string &category() const;
 
-		//! Location type, e.g. "city", "town", "village" (GeoNames feature code)
+		/**
+		 * @brief Location type derived from GeoNames feature codes.
+		 *
+		 * One of the following values (or empty if unknown):
+		 *   "city"    — capital or administrative centre (PPLC, PPLA, PPLA2)
+		 *   "town"    — populated place or minor admin centre (PPL, PPLA3, PPLA4)
+		 *   "village" — small settlement (PPLF, PPLL, PPLR, PPLS, etc.)
+		 *   "suburb"  — section of a populated place (PPLX)
+		 */
 		void setType(const std::string &);
 		const std::string &type() const;
 
-		//! Administrative region abbreviation, e.g. "NSW"
-		void setState(const std::string &);
-		const std::string &state() const;
-
-		//! Full administrative region name, e.g. "New South Wales"
-		void setStateFull(const std::string &);
-		const std::string &stateFull() const;
+		/**
+		 * @brief Administrative region (state/province).
+		 *
+		 * Serializes as a child element, e.g.:
+		 * @code
+		 *   <state abbr="NSW"><name>New South Wales</name></state>
+		 * @endcode
+		 * The @c abbr field holds the ISO 3166-2 subdivision suffix (alphabetic
+		 * portion only). It is left empty where no alphabetic ISO code exists.
+		 */
+		void setAdminRegion(const AdminRegion &);
+		const AdminRegion &adminRegion() const;
 
 		void serialize(Core::BaseObject::Archive& ar) override;
 
 	private:
 		std::string _countryID;
+		std::string _country;
 		double _population;
 		std::string _category;
 		std::string _type;
-		std::string _state;
-		std::string _stateFull;
+		AdminRegion _adminRegion;
 };
 
 

--- a/libs/seiscomp/math/coord.h
+++ b/libs/seiscomp/math/coord.h
@@ -90,9 +90,9 @@ typedef NamedCoord<double> NamedCoordD;
 MAKEENUM(
 	CityType,
 	EVALUES(
-		CITYTYPE_UNKNOWN, //!< Absent or unrecognised type attribute
-		CITYTYPE_CITY,    //!< Capital or administrative centre (PPLC, PPLA, PPLA2)
-		CITYTYPE_TOWN,    //!< Populated place or minor admin centre (PPL, PPLA3, PPLA4)
+		CITYTYPE_UNKNOWN, //!< Absent or unrecognized type attribute
+		CITYTYPE_CITY,    //!< Capital or administrative center (PPLC, PPLA, PPLA2)
+		CITYTYPE_TOWN,    //!< Populated place or minor admin center (PPL, PPLA3, PPLA4)
 		CITYTYPE_VILLAGE, //!< Small settlement (PPLF, PPLL, PPLR, PPLS, etc.)
 		CITYTYPE_SUBURB   //!< Section of a populated place (PPLX)
 	),

--- a/libs/seiscomp/math/coord.h
+++ b/libs/seiscomp/math/coord.h
@@ -23,6 +23,7 @@
 
 #include <seiscomp/core/baseobject.h>
 #include <seiscomp/core/enumeration.h>
+#include <seiscomp/core/optional.h>
 #include <string>
 
 
@@ -178,8 +179,8 @@ class City : public NamedCoord<T> {
 		std::string _country;
 		double _population;
 		std::string _category;
-		CityType _type;
-		AdminRegion _adminRegion;
+		OPT(CityType) _type;
+		OPT(AdminRegion) _adminRegion;
 };
 
 


### PR DESCRIPTION
Extends `City<T>` with three new fields to enable richer location descriptions in SeisComP applications.

## Changes

### `AdminRegion` struct (replaces flat `state`/`stateFull` strings)

A dedicated struct serialised as a child element:

```xml
<state abbr="NSW"><name>New South Wales</name></state>
```

- `abbr` — ISO 3166-2 alphabetic subdivision suffix (e.g. `NSW`, `CA`); empty where only numeric codes exist (e.g. Japan, China, Türkiye)
- `name` — full subdivision name

### `country` field

Full English country name serialised as a `<country>` child element:

```xml
<country>Australia</country>
```

Allows applications to display a human-readable country name without maintaining a separate ISO A2 → name lookup table.

### `type` field

Location type derived from GeoNames feature codes. One of (or empty if unknown):

| Value | Meaning |
|-------|---------|
| `city` | Capital or administrative centre (PPLC, PPLA, PPLA2) |
| `town` | Populated place or minor admin centre (PPL, PPLA3, PPLA4) |
| `village` | Small settlement (PPLF, PPLL, PPLR, PPLS, etc.) |
| `suburb` | Section of a populated place (PPLX) |

## Updated `cities.xml`

Re-enriched from freely available sources:

| Field | Source | Coverage |
|-------|--------|----------|
| `countryID` | Natural Earth 10m country polygons | 71,682 / 71,685 |
| `country` | Natural Earth SQLite (`ne_10m_admin_0_countries`) | 70,242 |
| `state` | Natural Earth `ne_10m_admin_1_states_provinces` (ISO 3166-2 abbreviations) | 71,654 |
| `type` | GeoNames `cities500.txt` feature codes | 56,860 |

All fields are optional and additive — existing applications ignoring them are unaffected.

## Enrichment tooling

The pipeline script used to produce the enriched `cities.xml` is available at
https://github.com/comoglu/cities-xml-update — allowing operators to add their own cities or re-enrich from updated upstream data.