### PR TITLE
[datamodel] Add generic event filter expression infrastructure

### DIFF
--- a/libs/seiscomp/datamodel/CMakeLists.txt
+++ b/libs/seiscomp/datamodel/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(DM_SOURCES
 	publicobject.cpp
 	diff.cpp
 	utils.cpp
+	filter.cpp
 )
 
 SET(DM_HEADERS
@@ -27,6 +28,7 @@ SET(DM_HEADERS
 	publicobject.h
 	diff.h
 	utils.h
+	filter.h
 	${CORE_DATAMODEL_GENERATED_HEADERS}
 )
 

--- a/libs/seiscomp/datamodel/filter.cpp
+++ b/libs/seiscomp/datamodel/filter.cpp
@@ -1,0 +1,349 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+
+#include "filter.h"
+
+#include <seiscomp/utils/leparser.h>
+#include <seiscomp/datamodel/originquality.h>
+
+#include <algorithm>
+#include <stdexcept>
+
+
+namespace Seiscomp {
+namespace DataModel {
+
+
+namespace {
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// Normalise a string value for case-insensitive, punctuation-tolerant matching:
+// lowercase, spaces → hyphens, underscores → hyphens.
+// Applied to both actual enum strings and user-supplied condition values so
+// that e.g. "not existing", "not_existing" and "not-existing" all match.
+std::string normalise(const std::string &s) {
+	std::string v(s);
+	std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+	std::replace(v.begin(), v.end(), ' ', '-');
+	std::replace(v.begin(), v.end(), '_', '-');
+	return v;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+class FilterAndExpression : public Utils::BinaryOperator<FilterExpression> {
+	public:
+		bool eval(const FilterContext &ctx) const override {
+			return _lhs->eval(ctx) && _rhs->eval(ctx);
+		}
+};
+
+
+class FilterOrExpression : public Utils::BinaryOperator<FilterExpression> {
+	public:
+		bool eval(const FilterContext &ctx) const override {
+			return _lhs->eval(ctx) || _rhs->eval(ctx);
+		}
+};
+
+
+class FilterNotExpression : public Utils::UnaryOperator<FilterExpression> {
+	public:
+		bool eval(const FilterContext &ctx) const override {
+			return !_rhs->eval(ctx);
+		}
+};
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// Leaf expression: evaluates key <op> value against a FilterContext.
+// Supports ==, !=, <, >, <=, >= operators.
+// Numeric comparison is attempted first; falls back to string for == and !=.
+class FilterLeafExpression : public FilterExpression {
+	public:
+		enum Op { EQ, LT, GT, LE, GE };
+
+		FilterLeafExpression(const std::string &key, Op op,
+		                     const std::string &value)
+		: _key(key), _op(op) {
+			// Pre-parse numeric value if possible
+			try {
+				_numericValue = std::stod(value);
+				_hasNumeric = true;
+				_value = value;
+			}
+			catch ( ... ) {
+				_hasNumeric = false;
+				_numericValue = 0.0;
+				// Normalise string values so that e.g. "not existing",
+				// "not_existing" and "not-existing" all match the same enum string.
+				_value = normalise(value);
+			}
+		}
+
+		bool eval(const FilterContext &ctx) const override {
+			// Try numeric comparison first
+			if ( _hasNumeric ) {
+				double actual;
+				if ( ctx.getDouble(_key, actual) )
+					return compareDouble(actual);
+			}
+
+			// Fall back to string comparison (== only; != is expressed as !(key==value))
+			if ( _op == EQ ) {
+				std::string actual;
+				if ( ctx.getString(_key, actual) )
+					return actual == _value;
+			}
+
+			return false;
+		}
+
+	private:
+		bool compareDouble(double actual) const {
+			switch ( _op ) {
+				case EQ: return actual == _numericValue;
+				case LT: return actual <  _numericValue;
+				case GT: return actual >  _numericValue;
+				case LE: return actual <= _numericValue;
+				case GE: return actual >= _numericValue;
+			}
+			return false;
+		}
+
+		std::string _key;
+		Op          _op;
+		std::string _value;
+		double      _numericValue;
+		bool        _hasNumeric;
+};
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// Parses a leaf token of the form "key==value", "key<value", "key>=value" etc.
+// Note: != is NOT supported here because the LeTokenizer splits '!' as the
+// logical NOT operator before this function is ever called. Use !(key==value)
+// to express not-equal in condition strings.
+// Returns nullptr and sets errorMsg on failure.
+FilterExpression *parseLeaf(const std::string &token, std::string &errorMsg) {
+	// Operators ordered longest-first to avoid partial matches
+	static const struct { const char *sym; FilterLeafExpression::Op op; } ops[] = {
+		{ "==", FilterLeafExpression::EQ },
+		{ "<=", FilterLeafExpression::LE },
+		{ ">=", FilterLeafExpression::GE },
+		{ "<",  FilterLeafExpression::LT },
+		{ ">",  FilterLeafExpression::GT },
+	};
+
+	for ( const auto &entry : ops ) {
+		auto pos = token.find(entry.sym);
+		if ( pos == std::string::npos ) continue;
+
+		std::string key   = token.substr(0, pos);
+		std::string value = token.substr(pos + std::strlen(entry.sym));
+
+		// Trim whitespace
+		auto trim = [](std::string &s) {
+			auto a = s.find_first_not_of(" \t");
+			auto b = s.find_last_not_of(" \t");
+			s = (a == std::string::npos) ? "" : s.substr(a, b - a + 1);
+		};
+		trim(key);
+		trim(value);
+
+		if ( key.empty() ) {
+			errorMsg = "Empty key in token: " + token;
+			return nullptr;
+		}
+
+		return new FilterLeafExpression(key, entry.op, value);
+	}
+
+	errorMsg = "No operator found in token: " + token;
+	return nullptr;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+class FilterExpressionFactory
+    : public Utils::ExpressionFactoryInterface<FilterExpression> {
+	public:
+		FilterExpressionFactory(std::string &errorMsg) : _errorMsg(errorMsg) {}
+
+		FilterExpression *createAndExpression() override {
+			return new FilterAndExpression;
+		}
+		FilterExpression *createOrExpression() override {
+			return new FilterOrExpression;
+		}
+		FilterExpression *createNotExpression() override {
+			return new FilterNotExpression;
+		}
+		FilterExpression *createExpression(const std::string &token) override {
+			return parseLeaf(token, _errorMsg);
+		}
+
+	private:
+		std::string &_errorMsg;
+};
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+} // anonymous namespace
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+FilterExpression *parseFilterExpression(const std::string &condition,
+                                        std::string &errorMsg) {
+	errorMsg.clear();
+
+	Utils::LeTokenizer tokenizer(condition);
+	if ( !tokenizer.tokenize() || tokenizer.error() ) {
+		errorMsg = tokenizer.what();
+		return nullptr;
+	}
+
+	FilterExpressionFactory factory(errorMsg);
+	Utils::LeParser<FilterExpression> parser(tokenizer.tokens(), &factory);
+
+	FilterExpression *expr = parser.parse();
+	if ( parser.error() ) {
+		errorMsg = parser.what();
+		delete expr;
+		return nullptr;
+	}
+
+	if ( !errorMsg.empty() ) {
+		delete expr;
+		return nullptr;
+	}
+
+	return expr;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+EventFilterContext::EventFilterContext(const Event *event,
+                                       const Origin *origin,
+                                       const Magnitude *magnitude)
+: _event(event), _origin(origin), _magnitude(magnitude) {}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool EventFilterContext::getString(const std::string &key,
+                                   std::string &value) const {
+	if ( !_event ) return false;
+
+	if ( key == "type" ) {
+		try { value = normalise(_event->type().toString()); return true; }
+		catch ( ... ) { return false; }
+	}
+	if ( key == "typecertainty" ) {
+		try { value = normalise(_event->typeCertainty().toString()); return true; }
+		catch ( ... ) { return false; }
+	}
+
+	if ( !_origin ) return false;
+
+	if ( key == "evaluationstatus" ) {
+		try { value = normalise(_origin->evaluationStatus().toString()); return true; }
+		catch ( ... ) { return false; }
+	}
+	if ( key == "evaluationmode" ) {
+		try { value = normalise(_origin->evaluationMode().toString()); return true; }
+		catch ( ... ) { return false; }
+	}
+	if ( key == "agencyid" ) {
+		try { value = _origin->creationInfo().agencyID(); return true; }
+		catch ( ... ) { return false; }
+	}
+	if ( key == "author" ) {
+		try { value = _origin->creationInfo().author(); return true; }
+		catch ( ... ) { return false; }
+	}
+
+	return false;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool EventFilterContext::getDouble(const std::string &key,
+                                   double &value) const {
+	if ( _origin ) {
+		if ( key == "lat" || key == "latitude" ) {
+			try { value = _origin->latitude().value(); return true; }
+			catch ( ... ) { return false; }
+		}
+		if ( key == "lon" || key == "longitude" ) {
+			try { value = _origin->longitude().value(); return true; }
+			catch ( ... ) { return false; }
+		}
+		if ( key == "depth" ) {
+			try { value = _origin->depth().value(); return true; }
+			catch ( ... ) { return false; }
+		}
+		if ( key == "rms" ) {
+			try { value = _origin->quality().standardError(); return true; }
+			catch ( ... ) { return false; }
+		}
+		if ( key == "azimuthalgap" ) {
+			try { value = _origin->quality().azimuthalGap(); return true; }
+			catch ( ... ) { return false; }
+		}
+	}
+
+	if ( _magnitude ) {
+		if ( key == "magnitude" ) {
+			try { value = _magnitude->magnitude().value(); return true; }
+			catch ( ... ) { return false; }
+		}
+	}
+
+	return false;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+} // namespace DataModel
+} // namespace Seiscomp

--- a/libs/seiscomp/datamodel/filter.h
+++ b/libs/seiscomp/datamodel/filter.h
@@ -1,0 +1,138 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+
+#ifndef SEISCOMP_DATAMODEL_FILTER_H
+#define SEISCOMP_DATAMODEL_FILTER_H
+
+
+#include <seiscomp/core.h>
+#include <seiscomp/datamodel/event.h>
+#include <seiscomp/datamodel/origin.h>
+#include <seiscomp/datamodel/magnitude.h>
+
+#include <string>
+
+
+namespace Seiscomp {
+namespace DataModel {
+
+
+/**
+ * @brief Abstract context providing named value lookup for filter evaluation.
+ *
+ * Subclasses bind a specific data model object (e.g. Event + Origin) to
+ * a flat key/value interface that FilterExpression nodes can query.
+ *
+ * Each key may resolve to a string value, a numeric (double) value, or
+ * neither. Implementations should return false from the relevant getter
+ * if the key is unknown or the value is not set on the underlying object.
+ */
+class SC_SYSTEM_CORE_API FilterContext {
+	public:
+		virtual ~FilterContext() {}
+
+		virtual bool getString(const std::string &key,
+		                       std::string &value) const = 0;
+		virtual bool getDouble(const std::string &key,
+		                       double &value) const = 0;
+};
+
+
+/**
+ * @brief Abstract expression node in a filter expression tree.
+ *
+ * Each node evaluates to true or false given a FilterContext.
+ * Trees are built by parseFilterExpression() using the LeParser
+ * infrastructure and evaluated by calling eval() on the root.
+ */
+class SC_SYSTEM_CORE_API FilterExpression {
+	public:
+		virtual ~FilterExpression() {}
+		virtual bool eval(const FilterContext &ctx) const = 0;
+};
+
+
+/**
+ * @brief Concrete FilterContext for an Event and its preferred Origin.
+ *
+ * Supported string keys (all lowercase, case-sensitive):
+ *   type               — event type (e.g. "earthquake", "not-existing")
+ *   evaluationstatus   — origin evaluation status (e.g. "preliminary", "confirmed")
+ *   evaluationmode     — origin evaluation mode ("automatic", "manual")
+ *   typecertainty      — event type certainty ("known", "suspected", "damaging", "felt")
+ *   agencyid           — agency ID from the preferred origin's creation info
+ *   author             — author from the preferred origin's creation info
+ *
+ * Supported double keys (all lowercase, case-sensitive):
+ *   lat / latitude     — preferred origin latitude in degrees
+ *   lon / longitude    — preferred origin longitude in degrees
+ *   depth              — preferred origin depth in km
+ *   magnitude          — preferred magnitude value
+ *   rms                — origin quality RMS residual
+ *   azimuthalgap       — origin quality azimuthal gap in degrees
+ *
+ * String values on both sides of a comparison are normalised to lowercase
+ * with spaces and underscores replaced by hyphens, so "not-existing",
+ * "not existing" and "not_existing" all match the same enum string.
+ * Keys are NOT normalised — they must be written in lowercase exactly as
+ * listed above.
+ */
+class SC_SYSTEM_CORE_API EventFilterContext : public FilterContext {
+	public:
+		EventFilterContext(const Event *event, const Origin *origin,
+		                   const Magnitude *magnitude = nullptr);
+
+		bool getString(const std::string &key, std::string &value) const override;
+		bool getDouble(const std::string &key, double &value) const override;
+
+	private:
+		const Event     *_event;
+		const Origin    *_origin;
+		const Magnitude *_magnitude;
+};
+
+
+/**
+ * @brief Parse a condition string into a FilterExpression tree.
+ *
+ * Boolean operators: & (AND), | (OR), ! (NOT), parentheses for grouping.
+ * Leaf format:  key==value  key<value  key>value  key<=value  key>=value
+ *
+ * Note: != is NOT a valid leaf operator because the LeTokenizer treats '!'
+ * as the logical NOT operator and splits it from the rest of the token.
+ * To express not-equal, use the NOT operator: !(key==value).
+ *
+ * String comparison uses == only (with the NOT wrapper for not-equal).
+ * Numeric comparison supports == < > <= >=; the value is parsed as a double.
+ * If the value cannot be parsed as a number, string == is used as fallback.
+ *
+ * Returns nullptr on parse error and sets errorMsg accordingly.
+ * The caller owns the returned expression.
+ */
+SC_SYSTEM_CORE_API
+FilterExpression *parseFilterExpression(const std::string &condition,
+                                        std::string &errorMsg);
+
+
+} // namespace DataModel
+} // namespace Seiscomp
+
+
+#endif

--- a/libs/seiscomp/utils/leparser.h
+++ b/libs/seiscomp/utils/leparser.h
@@ -96,7 +96,7 @@ class BinaryOperator : public Expression {
 			if (_rhs) delete _rhs;
 		}
 
-	private:
+	protected:
 		Expression* _lhs;
 		Expression* _rhs;
 };
@@ -118,7 +118,7 @@ class UnaryOperator : public Expression {
 			if (_rhs) delete _rhs;
 		}
 
-	private:
+	protected:
 		Expression* _rhs;
 };
 


### PR DESCRIPTION
## What this does

Adds a small filter library to `seiscomp/datamodel` that lets any application evaluate a condition string against an event and its preferred origin or magnitude.

The condition syntax builds on the existing `leparser` in `seiscomp/utils` for boolean logic (`&` AND, `|` OR, `!` NOT, parentheses for grouping). Leaf conditions take the form `key==value`, `key<value`, `key>=value` etc. Because the leparser treats `!` as the logical NOT operator, not-equal is written as `!(key==value)` rather than `key!=value`.

## New API

Three classes in `seiscomp/datamodel/filter.h`:

- **`FilterContext`** — abstract interface; subclasses provide named key/value lookup for a specific data object
- **`FilterExpression`** — abstract expression node; trees are built by `parseFilterExpression()`  
- **`EventFilterContext`** — concrete binding of `Event` + `Origin` + `Magnitude` to the filter interface

Free function:

```cpp
FilterExpression *parseFilterExpression(const std::string &condition,
                                        std::string &errorMsg);
```

## Supported keys

String keys: `type`, `evaluationstatus`, `evaluationmode`, `typecertainty`, `agencyid`, `author`

Numeric keys: `lat`, `lon`, `depth`, `magnitude`, `rms`, `azimuthalgap`

String values are normalised to lowercase with spaces and underscores converted to hyphens on both sides of a comparison, so `"not existing"` and `"not-existing"` match the same enum string.

## Example

```cpp
std::string err;
std::unique_ptr<FilterExpression> expr(
    parseFilterExpression("type==earthquake & evaluationstatus==preliminary", err));

EventFilterContext ctx(event, origin, magnitude);
if ( expr && expr->eval(ctx) ) {
    // matched
}
```

## leparser.h change

`_lhs`/`_rhs` in `BinaryOperator` and `_rhs` in `UnaryOperator` are changed from `private` to `protected` so that subclasses can implement `eval()`.

## Notes

This PR is the dependency for a companion PR in `seiscomp/main` that uses `EventFilterContext` to drive configurable event list row highlighting in scolv.