### PR TITLE
[seismology] Add computeAzimuthalGaps() and fix secondary gap in compile()

### DIFF
--- a/libs/seiscomp/seismology/locator/utils.cpp
+++ b/libs/seiscomp/seismology/locator/utils.cpp
@@ -30,6 +30,35 @@
 namespace Seiscomp{
 
 
+bool computeAzimuthalGaps(const std::vector<double> &azimuths,
+                          double &primary, double &secondary) {
+	if ( azimuths.size() < 2 ) {
+		return false;
+	}
+
+	std::vector<double> azi(azimuths);
+	std::sort(azi.begin(), azi.end());
+
+	primary = secondary = 0.;
+	size_t n = azi.size();
+	azi.push_back(azi[0] + 360.);
+	azi.push_back(azi[1] + 360.);
+
+	for ( size_t i = 0; i < n; ++i ) {
+		double g1 = azi[i + 1] - azi[i];
+		if ( g1 > primary ) {
+			primary = g1;
+		}
+		double g2 = azi[i + 2] - azi[i];
+		if ( g2 > secondary ) {
+			secondary = g2;
+		}
+	}
+
+	return true;
+}
+
+
 void compile(DataModel::OriginQuality &quality, const DataModel::Origin *origin) {
 	int usedPhases = 0;
 	int usedDepthPhases = 0;
@@ -77,15 +106,11 @@ void compile(DataModel::OriginQuality &quality, const DataModel::Origin *origin)
 	}
 
 	if ( !azi.empty() ) {
-		std::sort(azi.begin(), azi.end());
-		azi.push_back(azi.front()+360.);
-		double azGap = 0.;
-		if ( azi.size() > 2 )
-			for ( size_t i = 0; i < azi.size()-1; ++i )
-				azGap = (azi[i+1]-azi[i]) > azGap ? (azi[i+1]-azi[i]) : azGap;
-
-		if ( 0. < azGap && azGap < 360. )
-			quality.setAzimuthalGap(azGap);
+		double primaryGap, secondaryGap;
+		if ( computeAzimuthalGaps(azi, primaryGap, secondaryGap) ) {
+			quality.setAzimuthalGap(primaryGap);
+			quality.setSecondaryAzimuthalGap(secondaryGap);
+		}
 	}
 
 	if ( !dist.empty() ) {

--- a/libs/seiscomp/seismology/locator/utils.h
+++ b/libs/seiscomp/seismology/locator/utils.h
@@ -21,6 +21,7 @@
 #ifndef SEISCOMP_SEISMOLOGY_LOCATOR_UTILS_H
 #define SEISCOMP_SEISMOLOGY_LOCATOR_UTILS_H
 
+#include <vector>
 
 namespace Seiscomp{
 
@@ -33,12 +34,28 @@ class OriginQuality;
 
 
 /**
+ * @brief Computes primary and secondary azimuthal gaps from a list of azimuths.
+ *
+ * Primary gap: largest angular gap between any two adjacent stations.
+ * Secondary gap: largest angular gap that would remain if any one station
+ * were removed (i.e., the largest span covered by two consecutive gaps).
+ *
+ * @param azimuths Station azimuths in degrees [0, 360). Need not be sorted.
+ * @param primary  Output: primary azimuthal gap in degrees.
+ * @param secondary Output: secondary azimuthal gap in degrees.
+ * @return false if fewer than 2 azimuths are provided (gaps undefined).
+ */
+bool computeAzimuthalGaps(const std::vector<double> &azimuths,
+                          double &primary, double &secondary);
+
+
+/**
  * @brief Compiles an origin quality object from an origin.
  * Computed attributes:
  *  * minimum distance
  *  * median distance
  *  * maximum distance
- *  * azimuthal gap
+ *  * azimuthal gap (primary and secondary)
  *  * associated phase count
  *  * used phase count
  *  * depth phase count


### PR DESCRIPTION
## Problem

`populateQuality()` / `compile()` in `seismology/locator/utils` computes the primary azimuthal gap but never sets `secondaryAzimuthalGap` in `OriginQuality`, leaving the field unset for any locator that relies on this utility (locsat, etc.).

Additionally, the sort-and-scan logic for computing azimuthal gaps is duplicated across scautoloc (`determineAzimuthalGaps` / `geoProperties`), stdloc, and scrtdd — each with a slightly different implementation.

## Fix

- Add a standalone library function `computeAzimuthalGaps(const std::vector<double> &azimuths, double *primary, double *secondary)` to `seismology/locator/utils` that accepts raw azimuths and computes both the primary and secondary gaps.
- Update `compile()` to call `computeAzimuthalGaps()` and populate `secondaryAzimuthalGap`.

This gives other modules (scautoloc, future locators) a single authoritative implementation to call, as discussed with @jsaul.

## Related

Companion PR in SeisComP/main: scautoloc sc3adapters — export `secondaryAzimuthalGap` on the converted origin.