### PR TITLE
[gui] Show origin quality grade in scolv and scesv with tooltip breakdown

### DIFF
--- a/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
@@ -1774,9 +1774,18 @@ void EventSummaryView::setOrigin(Seiscomp::DataModel::Origin *origin) {
 			_reader->loadComments(_currentOrigin.get());
 
 		_uiHypocenter->_lbComment->setText(_displayCommentDefault.c_str());
+		_uiHypocenter->_lbComment->setToolTip(QString());
 		for ( size_t i = 0; i < _currentOrigin->commentCount(); ++i ) {
 			if ( _currentOrigin->comment(i)->id() == _displayCommentID ) {
-				_uiHypocenter->_lbComment->setText(_currentOrigin->comment(i)->text().c_str());
+				QString fullText = _currentOrigin->comment(i)->text().c_str();
+				int sep = fullText.indexOf('\n');
+				if ( sep >= 0 ) {
+					_uiHypocenter->_lbComment->setText(fullText.left(sep));
+					_uiHypocenter->_lbComment->setToolTip(fullText.mid(sep + 1));
+				}
+				else {
+					_uiHypocenter->_lbComment->setText(fullText);
+				}
 				break;
 			}
 		}
@@ -1954,9 +1963,18 @@ void EventSummaryView::setAutomaticOrigin(DataModel::Origin* origin) {
 			_reader->loadComments(origin);
 
 		_uiHypocenter->_lbCommentAutomatic->setText(_displayCommentDefault.c_str());
+		_uiHypocenter->_lbCommentAutomatic->setToolTip(QString());
 		for ( size_t i = 0; i < origin->commentCount(); ++i ) {
 			if ( origin->comment(i)->id() == _displayCommentID ) {
-				_uiHypocenter->_lbCommentAutomatic->setText(origin->comment(i)->text().c_str());
+				QString fullText = origin->comment(i)->text().c_str();
+				int sep = fullText.indexOf('\n');
+				if ( sep >= 0 ) {
+					_uiHypocenter->_lbCommentAutomatic->setText(fullText.left(sep));
+					_uiHypocenter->_lbCommentAutomatic->setToolTip(fullText.mid(sep + 1));
+				}
+				else {
+					_uiHypocenter->_lbCommentAutomatic->setText(fullText);
+				}
 				break;
 			}
 		}

--- a/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventsummaryview.cpp
@@ -972,10 +972,10 @@ void EventSummaryView::init() {
 		_ui->labelCustomValue->setVisible(false);
 	}
 
-	_displayComment = false;
+	_displayCommentID = "quality";
+	_displayComment = true;
 	try {
 		_displayCommentID = SCApp->configGetString("display.origin.comment.id");
-		_displayComment = true;
 	}
 	catch ( ... ) {}
 
@@ -994,7 +994,7 @@ void EventSummaryView::init() {
 		_uiHypocenter->_lbCommentTxt->setText(QString("%1:").arg(SCApp->configGetString("display.origin.comment.label").c_str()));
 	}
 	catch ( ... ) {
-		_uiHypocenter->_lbCommentTxt->setText(_displayCommentID.c_str());
+		_uiHypocenter->_lbCommentTxt->setText("Quality:");
 	}
 
 	_maxHotspotDist = 20.0;

--- a/libs/seiscomp/gui/datamodel/originlocatorview.cpp
+++ b/libs/seiscomp/gui/datamodel/originlocatorview.cpp
@@ -3322,14 +3322,6 @@ void OriginLocatorView::init() {
 
 	SC_D.ui.lbComment->setVisible(SC_D.displayComment);
 	SC_D.ui.labelComment->setVisible(SC_D.displayComment);
-	SC_D.ui.lbComment->setToolTip(
-		"Automatic quality grade (worst-of rule):\n"
-		"  Grade  Gap    Sec.Gap  RMS      Stations  Min.Dist\n"
-		"  A      ≤90°   ≤135°    ≤0.15s   ≥10       ≤30°\n"
-		"  B      ≤135°  ≤180°    ≤0.30s   ≥6        ≤60°\n"
-		"  C      ≤180°  ≤210°    ≤0.50s   ≥4        ≤90°\n"
-		"  D      worse than C"
-	);
 
 	try {
 		SC_D.displayCommentDefault = SCApp->configGetString("display.origin.comment.default");

--- a/libs/seiscomp/gui/datamodel/originlocatorview.cpp
+++ b/libs/seiscomp/gui/datamodel/originlocatorview.cpp
@@ -228,7 +228,9 @@ struct CommitOptions {
 			profile.value = string();
 			auto comment = origin ? origin->comment(profile.id) : nullptr;
 			if ( comment ) {
-				profile.value = comment->text();
+				auto text = comment->text();
+				auto nl = text.find('\n');
+				profile.value = nl != string::npos ? text.substr(0, nl) : text;
 			}
 		}
 	}
@@ -7993,7 +7995,10 @@ void OriginLocatorView::commitWithOptions(const void *data_ptr) {
 				}
 				else {
 					if ( comment ) {
-						if ( profile.value != comment->text() ) {
+						auto existingText = comment->text();
+						auto nl = existingText.find('\n');
+						auto existingGrade = nl != string::npos ? existingText.substr(0, nl) : existingText;
+						if ( profile.value != existingGrade ) {
 							comment->setText(profile.value);
 							comment->update();
 							if ( !Notifier::IsEnabled()) {

--- a/libs/seiscomp/gui/datamodel/originlocatorview.cpp
+++ b/libs/seiscomp/gui/datamodel/originlocatorview.cpp
@@ -3320,6 +3320,14 @@ void OriginLocatorView::init() {
 
 	SC_D.ui.lbComment->setVisible(SC_D.displayComment);
 	SC_D.ui.labelComment->setVisible(SC_D.displayComment);
+	SC_D.ui.lbComment->setToolTip(
+		"Automatic quality grade (worst-of rule):\n"
+		"  Grade  Gap    Sec.Gap  RMS      Stations  Min.Dist\n"
+		"  A      ≤90°   ≤135°    ≤0.15s   ≥10       ≤30°\n"
+		"  B      ≤135°  ≤180°    ≤0.30s   ≥6        ≤60°\n"
+		"  C      ≤180°  ≤210°    ≤0.50s   ≥4        ≤90°\n"
+		"  D      worse than C"
+	);
 
 	try {
 		SC_D.displayCommentDefault = SCApp->configGetString("display.origin.comment.default");
@@ -4774,6 +4782,22 @@ void OriginLocatorView::setPickerView(PickerView* picker) {
 
 
 
+// Sets the comment label text and tooltip. If the text contains a newline,
+// the first line is shown as the label and the remainder becomes the tooltip.
+static void setCommentLabel(QLabel *label, const QString &text) {
+	int sep = text.indexOf('\n');
+	if ( sep >= 0 ) {
+		label->setText(text.left(sep));
+		label->setToolTip(text.mid(sep + 1));
+	}
+	else {
+		label->setText(text);
+		label->setToolTip(QString());
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 void OriginLocatorView::addObject(const QString &parentID, Seiscomp::DataModel::Object *o) {
 	if ( SC_D.currentOrigin ) {
@@ -4818,7 +4842,7 @@ void OriginLocatorView::addObject(const QString &parentID, Seiscomp::DataModel::
 			if ( parentID == SC_D.currentOrigin->publicID().c_str() ) {
 				Comment *comment = Comment::Cast(o);
 				if ( comment && comment->id() == SC_D.displayCommentID )
-					SC_D.ui.labelComment->setText(comment->text().c_str());
+					setCommentLabel(SC_D.ui.labelComment, comment->text().c_str());
 			}
 		}
 	}
@@ -4848,7 +4872,7 @@ void OriginLocatorView::updateObject(const QString& parentID, Seiscomp::DataMode
 			if ( parentID == SC_D.currentOrigin->publicID().c_str() ) {
 				Comment *comment = Comment::Cast(o);
 				if ( comment && comment->id() == SC_D.displayCommentID )
-					SC_D.ui.labelComment->setText(comment->text().c_str());
+					setCommentLabel(SC_D.ui.labelComment, comment->text().c_str());
 			}
 		}
 	}
@@ -5371,13 +5395,14 @@ void OriginLocatorView::updateContent() {
 	}
 
 	SC_D.ui.labelComment->setText(SC_D.displayCommentDefault.c_str());
+	SC_D.ui.labelComment->setToolTip(QString());
 	if ( SC_D.displayComment ) {
 		if ( SC_D.reader && SC_D.currentOrigin->commentCount() == 0 )
 			SC_D.reader->loadComments(SC_D.currentOrigin.get());
 
 		for ( size_t i = 0; i < SC_D.currentOrigin->commentCount(); ++i ) {
 			if ( SC_D.currentOrigin->comment(i)->id() == SC_D.displayCommentID ) {
-				SC_D.ui.labelComment->setText(SC_D.currentOrigin->comment(i)->text().c_str());
+				setCommentLabel(SC_D.ui.labelComment, SC_D.currentOrigin->comment(i)->text().c_str());
 				break;
 			}
 		}

--- a/libs/seiscomp/gui/datamodel/originlocatorview.cpp
+++ b/libs/seiscomp/gui/datamodel/originlocatorview.cpp
@@ -3311,10 +3311,10 @@ void OriginLocatorView::init() {
 	SC_D.ui.groupBox->setFixedWidth(width);
 	*/
 
-	SC_D.displayComment = false;
+	SC_D.displayCommentID = "quality";
+	SC_D.displayComment = true;
 	try {
 		SC_D.displayCommentID = SCApp->configGetString("olv.display.origin.comment.id");
-		SC_D.displayComment = true;
 	}
 	catch ( ... ) {}
 
@@ -3332,7 +3332,7 @@ void OriginLocatorView::init() {
 		SC_D.ui.lbComment->setText(QString("%1:").arg(SCApp->configGetString("display.origin.comment.label").c_str()));
 	}
 	catch ( ... ) {
-		SC_D.ui.lbComment->setText(SC_D.displayCommentID.c_str());
+		SC_D.ui.lbComment->setText("Quality:");
 	}
 
 	try {

--- a/libs/seiscomp/gui/datamodel/originlocatorview.ui
+++ b/libs/seiscomp/gui/datamodel/originlocatorview.ui
@@ -860,7 +860,7 @@
         <item row="6" column="0" >
          <widget class="QLabel" name="lbComment" >
           <property name="text" >
-           <string>Custom:</string>
+           <string>Quality:</string>
           </property>
           <property name="alignment" >
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>


### PR DESCRIPTION
## Summary

Shows the origin quality grade (written by `scoriginquality`) by default in
both the scolv Location tab and the scesv hypocenter panel, with no
configuration required.

### Changes

**`eventsummaryview`** (scesv hypocenter panel):
- Default comment ID changed to `"quality"`, label to `"Quality:"`
- Both remain overridable via `display.origin.comment.id` and
  `display.origin.comment.label`

**`originlocatorview`** (scolv Location tab):
- Default comment ID changed to `"quality"`, label to `"Quality:"`
- Both remain overridable via `olv.display.origin.comment.id` and
  `display.origin.comment.label`
- Static tooltip on the `"Quality:"` label shows the full threshold table

**Tooltip support** (both views):
- `scoriginquality` stores grade + breakdown in a single comment using `\n`
  as separator (grade letter on line 1, one parameter per line after)
- The display code splits on the first `\n`: label shows the grade letter,
  `setToolTip()` shows the full per-parameter breakdown on hover

Example tooltip on hover over the grade value:
```
Az. Gap: 76.3° → A
Sec. Gap: 115.1° → B
RMS: 0.937 s → D
Stations: 12 → A
Min. Dist: 18.2° → A
Horiz. Unc.: 7.4 km → B
```

## Related PRs

- Module that computes and writes the grade: `comoglu/main:feature/scoriginquality` (SeisComP/main#117)

## Test plan

- [ ] Start scoriginquality + scolv; locate an event; confirm "Quality: B" (or similar) appears on Location tab without any config
- [ ] Hover over the grade value — confirm per-parameter breakdown tooltip
- [ ] Hover over "Quality:" label — confirm threshold table tooltip
- [ ] Start scesv; confirm grade appears in hypocenter panel
- [ ] Hover grade in scesv — confirm breakdown tooltip
- [ ] Set `display.origin.comment.id = myCustomID` — confirm custom comment still displays