### PR TITLE
[gui] Move event list row-highlight rules into EventListView

### DIFF
--- a/apps/gui/descriptions/global_gui.xml
+++ b/apps/gui/descriptions/global_gui.xml
@@ -1780,6 +1780,66 @@
 						</parameter>
 					</group>
 				</group>
+				<group name="highlight">
+					<description>
+					Configurable row colouring rules for the event list. Each named
+					rule defines a logical condition and the background/foreground
+					colours to apply when the condition matches. The first matching
+					rule wins; rows that match no rule revert to the default style.
+
+					Condition syntax: boolean expressions using &amp;&amp; (AND),
+					|| (OR) and ! (NOT). String values must be single-quoted;
+					numeric values are unquoted. Unset optional fields (e.g. no
+					preferred magnitude, typecertainty not set) are treated as null:
+					!= returns true, == returns false.
+
+					Supported string keys: type, typecertainty,
+					evaluationstatus (alias: status), evaluationmode (alias: mode),
+					agencyid, author.
+
+					Supported numeric keys: latitude (alias: lat),
+					longitude (alias: lon), depth, magnitude (alias: mag),
+					rms, azimuthalgap (alias: gap).
+
+					String values use SeisComP enum names as-is (lowercase with
+					spaces), e.g. 'earthquake', 'not existing', 'quarry blast'.
+
+					Example:
+					eventlist.highlight = auto, preliminary
+					eventlist.highlight.auto.condition = "evaluationmode == 'automatic'"
+					eventlist.highlight.auto.background = FF4100
+					eventlist.highlight.auto.foreground = 000000
+					</description>
+					<parameter name="highlight" type="list:string">
+						<description>
+						Ordered list of highlight rule names. The first rule whose
+						condition matches the event is applied; subsequent rules are
+						not evaluated.
+						</description>
+					</parameter>
+					<struct type="highlight rule" link="eventlist.highlight">
+						<parameter name="condition" type="string">
+							<description>
+							Logical expression evaluated against the event's preferred
+							origin, magnitude and event metadata. String values must
+							be single-quoted. Use &amp;&amp; for AND, || for OR, ! for NOT.
+							</description>
+						</parameter>
+						<parameter name="background" type="color">
+							<description>
+							Row background colour when this rule matches. Accepts a
+							6-digit hex value (e.g. FFA500) or a Qt named colour
+							(e.g. yellow).
+							</description>
+						</parameter>
+						<parameter name="foreground" type="color">
+							<description>
+							Row foreground (text) colour when this rule matches.
+							Accepts a 6-digit hex value or a Qt named colour.
+							</description>
+						</parameter>
+					</struct>
+				</group>
 			</group>
 			<group name="eventedit">
 				<description>

--- a/libs/seiscomp/gui/datamodel/eventlistview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventlistview.cpp
@@ -3334,32 +3334,26 @@ class EventKeyValueContext : public Utils::V2::LeKeyValueContext {
 
 		std::string getString(std::string_view key) const override {
 			if ( key == "type" ) {
-				try { return DataModel::EEventTypeNames::name(_event->type()); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return DataModel::EEventTypeNames::name(_event->type());
 			}
 			if ( key == "typecertainty" ) {
-				try { return DataModel::EEventTypeCertaintyNames::name(_event->typeCertainty()); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return DataModel::EEventTypeCertaintyNames::name(_event->typeCertainty());
 			}
 			if ( key == "evaluationstatus" || key == "status" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return DataModel::EEvaluationStatusNames::name(_origin->evaluationStatus()); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return DataModel::EEvaluationStatusNames::name(_origin->evaluationStatus());
 			}
 			if ( key == "evaluationmode" || key == "mode" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return DataModel::EEvaluationModeNames::name(_origin->evaluationMode()); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return DataModel::EEvaluationModeNames::name(_origin->evaluationMode());
 			}
 			if ( key == "agencyid" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return _origin->creationInfo().agencyID(); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return _origin->creationInfo().agencyID();
 			}
 			if ( key == "author" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return _origin->creationInfo().author(); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return _origin->creationInfo().author();
 			}
 			throw std::runtime_error(std::string("unknown key: ") + std::string(key));
 		}
@@ -3375,8 +3369,7 @@ class EventKeyValueContext : public Utils::V2::LeKeyValueContext {
 			}
 			if ( key == "depth" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return _origin->depth().value(); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return _origin->depth().value();
 			}
 			if ( key == "magnitude" || key == "mag" ) {
 				if ( !_magnitude ) throw Core::ValueException();
@@ -3384,13 +3377,11 @@ class EventKeyValueContext : public Utils::V2::LeKeyValueContext {
 			}
 			if ( key == "rms" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return _origin->quality().standardError(); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return _origin->quality().standardError();
 			}
 			if ( key == "azimuthalgap" || key == "gap" ) {
 				if ( !_origin ) throw Core::ValueException();
-				try { return _origin->quality().azimuthalGap(); }
-				catch ( ... ) { throw Core::ValueException(); }
+				return _origin->quality().azimuthalGap();
 			}
 			throw std::runtime_error(std::string("unknown key: ") + std::string(key));
 		}

--- a/libs/seiscomp/gui/datamodel/eventlistview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventlistview.cpp
@@ -3317,8 +3317,175 @@ EventListView::EventListView(Seiscomp::DataModel::DatabaseQuery* reader, bool wi
 
 	connect(&SC_D._otimeAgoTimer, SIGNAL(timeout()), this, SLOT(updateOTimeAgo()));
 	updateOTimeAgoTimer();
+	loadHighlightRules();
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+namespace {
+
+class EventKeyValueContext : public Utils::LeKeyValueContext {
+	public:
+		EventKeyValueContext(DataModel::Event *event,
+		                     DataModel::Origin *origin,
+		                     DataModel::Magnitude *magnitude)
+		    : _event(event), _origin(origin), _magnitude(magnitude) {}
+
+		std::string getString(std::string_view key) const override {
+			if ( key == "type" ) {
+				try { return DataModel::EEventTypeNames::name(_event->type()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "typecertainty" ) {
+				try { return DataModel::EEventTypeCertaintyNames::name(_event->typeCertainty()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "evaluationstatus" || key == "status" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return DataModel::EEvaluationStatusNames::name(_origin->evaluationStatus()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "evaluationmode" || key == "mode" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return DataModel::EEvaluationModeNames::name(_origin->evaluationMode()); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "agencyid" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->creationInfo().agencyID(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "author" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->creationInfo().author(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			throw std::runtime_error(std::string("unknown key: ") + std::string(key));
+		}
+
+		double getDouble(std::string_view key) const override {
+			if ( key == "latitude" || key == "lat" ) {
+				if ( !_origin ) throw Core::ValueException();
+				return _origin->latitude().value();
+			}
+			if ( key == "longitude" || key == "lon" ) {
+				if ( !_origin ) throw Core::ValueException();
+				return _origin->longitude().value();
+			}
+			if ( key == "depth" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->depth().value(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "magnitude" || key == "mag" ) {
+				if ( !_magnitude ) throw Core::ValueException();
+				return _magnitude->magnitude().value();
+			}
+			if ( key == "rms" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->quality().standardError(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			if ( key == "azimuthalgap" || key == "gap" ) {
+				if ( !_origin ) throw Core::ValueException();
+				try { return _origin->quality().azimuthalGap(); }
+				catch ( ... ) { throw Core::ValueException(); }
+			}
+			throw std::runtime_error(std::string("unknown key: ") + std::string(key));
+		}
+
+	private:
+		DataModel::Event     *_event;
+		DataModel::Origin    *_origin;
+		DataModel::Magnitude *_magnitude;
+};
+
+} // namespace
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void EventListView::loadHighlightRules() {
+	SC_D._highlightRules.clear();
+
+	std::vector<std::string> names;
+	try {
+		names = SCApp->configGetStrings("eventlist.highlight");
+	}
+	catch ( ... ) { return; }
+
+	Utils::LeKeyValueFactory factory;
+	Utils::LeParser::Symbols symbols = Utils::LeParser::DefaultSymbols();
+	symbols.reserved = Utils::LeKeyValueFactory::Reserved();
+	Utils::LeParser parser(&factory, &symbols);
+
+	for ( const auto &name : names ) {
+		const std::string base = "eventlist.highlight." + name;
+
+		std::string condStr;
+		try {
+			condStr = SCApp->configGetString(base + ".condition");
+		}
+		catch ( ... ) { continue; }
+
+		Utils::LeExpression *expr = nullptr;
+		try {
+			expr = parser.parse(condStr);
+		}
+		catch ( const std::exception &e ) {
+			SEISCOMP_WARNING("eventlist.highlight.%s: invalid condition: %s",
+			                 name.c_str(), e.what());
+			continue;
+		}
+
+		EventListViewPrivate::HighlightRule rule;
+		rule.expression = expr;
+		rule.background = SCApp->configGetColor(base + ".background", QColor());
+		rule.foreground = SCApp->configGetColor(base + ".foreground", QColor());
+		SC_D._highlightRules.emplace_back(std::move(rule));
+	}
+
+	SEISCOMP_INFO("Loaded %d event highlight rule(s)", (int)SC_D._highlightRules.size());
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void EventListView::applyHighlight(QTreeWidgetItem *item,
+                                   DataModel::Event *event,
+                                   DataModel::Origin *origin,
+                                   DataModel::Magnitude *magnitude) const {
+	if ( !event || SC_D._highlightRules.empty() ) return;
+
+	EventKeyValueContext ctx(event, origin, magnitude);
+
+	const EventListViewPrivate::HighlightRule *matched = nullptr;
+	for ( const auto &rule : SC_D._highlightRules ) {
+		if ( !rule.expression ) continue;
+		try {
+			if ( rule.expression->eval(&ctx) ) {
+				matched = &rule;
+				break;
+			}
+		}
+		catch ( ... ) {}
+	}
+
+	int cols = item->columnCount();
+	for ( int c = 0; c < cols; ++c ) {
+		if ( matched ) {
+			if ( matched->background.isValid() )
+				item->setBackground(c, matched->background);
+			if ( matched->foreground.isValid() )
+				item->setForeground(c, matched->foreground);
+		}
+		else {
+			item->setData(c, Qt::BackgroundRole, QVariant());
+			item->setData(c, Qt::ForegroundRole, QVariant());
+		}
+	}
+}
 
 
 
@@ -4627,6 +4794,7 @@ EventTreeItem* EventListView::addEvent(Seiscomp::DataModel::Event* event, bool f
 	SC_D._ui->btnClear->setEnabled(true);
 
 	updateEventProcessColumns(item, true);
+	applyHighlight(item, event, preferredOrigin.get(), preferredMagnitude.get());
 
 	return item;
 }
@@ -4863,6 +5031,8 @@ void EventListView::notifierAvailable(Seiscomp::DataModel::Notifier *n) {
 						if ( e && e->preferredOriginID() == o->publicID() ) {
 							parent->update(this);
 							emit eventUpdatedInList(e);
+							Magnitude *mag = Magnitude::Find(e->preferredMagnitudeID());
+							applyHighlight(parent, e, o, mag);
 						}
 					}
 					break;
@@ -4993,6 +5163,13 @@ void EventListView::notifierAvailable(Seiscomp::DataModel::Notifier *n) {
 					item->reset();
 					updateEventProcessColumns(item, true);
 					item->update(this);
+
+					{
+						Origin *prefOrigin = originItem
+						    ? static_cast<Origin*>(static_cast<SchemeTreeItem*>(originItem)->object())
+						    : preferredOrigin.get();
+						applyHighlight(item, event, prefOrigin, nm.get());
+					}
 
 					if ( SC_D._withFocalMechanisms ) {
 						auto *fmItem = findFocalMechanism(event->preferredFocalMechanismID());

--- a/libs/seiscomp/gui/datamodel/eventlistview.cpp
+++ b/libs/seiscomp/gui/datamodel/eventlistview.cpp
@@ -3325,7 +3325,7 @@ EventListView::EventListView(Seiscomp::DataModel::DatabaseQuery* reader, bool wi
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 namespace {
 
-class EventKeyValueContext : public Utils::LeKeyValueContext {
+class EventKeyValueContext : public Utils::V2::LeKeyValueContext {
 	public:
 		EventKeyValueContext(DataModel::Event *event,
 		                     DataModel::Origin *origin,
@@ -3415,10 +3415,10 @@ void EventListView::loadHighlightRules() {
 	}
 	catch ( ... ) { return; }
 
-	Utils::LeKeyValueFactory factory;
-	Utils::LeParser::Symbols symbols = Utils::LeParser::DefaultSymbols();
-	symbols.reserved = Utils::LeKeyValueFactory::Reserved();
-	Utils::LeParser parser(&factory, &symbols);
+	Utils::V2::LeKeyValueFactory factory;
+	Utils::V2::LeParser::Symbols symbols = Utils::V2::LeParser::DefaultSymbols();
+	symbols.reserved = Utils::V2::LeKeyValueFactory::Reserved();
+	Utils::V2::LeParser parser(&factory, &symbols);
 
 	for ( const auto &name : names ) {
 		const std::string base = "eventlist.highlight." + name;
@@ -3429,7 +3429,7 @@ void EventListView::loadHighlightRules() {
 		}
 		catch ( ... ) { continue; }
 
-		Utils::LeExpression *expr = nullptr;
+		Utils::V2::LeExpression *expr = nullptr;
 		try {
 			expr = parser.parse(condStr);
 		}

--- a/libs/seiscomp/gui/datamodel/eventlistview.h
+++ b/libs/seiscomp/gui/datamodel/eventlistview.h
@@ -293,6 +293,12 @@ class SC_GUI_API EventListView : public QWidget {
 
 		void loadItem(QTreeWidgetItem*);
 
+		void loadHighlightRules();
+		void applyHighlight(QTreeWidgetItem *item,
+		                    Seiscomp::DataModel::Event *event,
+		                    Seiscomp::DataModel::Origin *origin,
+		                    Seiscomp::DataModel::Magnitude *magnitude) const;
+
 		//! \since 17.0.0
 		void updateOTimeAgoTimer();
 

--- a/libs/seiscomp/gui/datamodel/eventlistview_p.h
+++ b/libs/seiscomp/gui/datamodel/eventlistview_p.h
@@ -87,7 +87,7 @@ class EventListViewPrivate {
 
 	public:
 		struct HighlightRule {
-			Utils::LeExpressionPtr expression;
+			Utils::V2::LeExpressionPtr expression;
 			QColor                 background;
 			QColor                 foreground;
 		};

--- a/libs/seiscomp/gui/datamodel/eventlistview_p.h
+++ b/libs/seiscomp/gui/datamodel/eventlistview_p.h
@@ -36,10 +36,14 @@
 
 #include "eventlistview.h"
 
+#include <seiscomp/core/exceptions.h>
 #include <seiscomp/gui/core/gradient.h>
 #include <seiscomp/gui/datamodel/ui_eventlistview.h>
+#include <seiscomp/utils/leparser.h>
 
+#include <QColor>
 #include <QTimer>
+#include <vector>
 
 
 namespace Seiscomp {
@@ -82,6 +86,13 @@ class EventListViewPrivate {
 		};
 
 	public:
+		struct HighlightRule {
+			Utils::LeExpressionPtr expression;
+			QColor                 background;
+			QColor                 foreground;
+		};
+
+	public:
 		EventListViewPrivate();
 		~EventListViewPrivate();
 
@@ -118,6 +129,7 @@ class EventListViewPrivate {
 		mutable int                         _visibleEventCount;
 		QTimer                              _otimeAgoTimer;
 		QString                             _exportScript;
+		std::vector<HighlightRule>          _highlightRules;
 
 	friend class EventListView;
 };


### PR DESCRIPTION
## What this does

Moves the configurable row-highlight feature into `EventListView` so all GUI tools using the widget (scolv, scesv, scmvx, …) benefit automatically — verified working in all three.

## How it works

`EventListView` reads `eventlist.highlight.*` rules at construction time using `Utils::LeKeyValueContext` / `LeKeyValueFactory` from `seiscomp/utils/leparser.h`. Highlight is applied in `addEvent()` and re-evaluated in `notifierAvailable()` when the preferred origin or event is updated.

An `EventKeyValueContext` (anonymous namespace in `eventlistview.cpp`) maps string and numeric keys to live datamodel objects. Unset optional fields throw `Core::ValueException` so null semantics work correctly with the leparser.

## Configuration

Rules are defined under `eventlist.highlight.*` in `global.cfg` so all tools share them. Parameter descriptions added to `global_gui.xml`.

Same condition syntax as documented in SeisComP/main#115.