### PR TITLE
[gui] add default ttt configuration for picker/amplitude views

### DIFF
--- a/apps/descriptions/global.xml
+++ b/apps/descriptions/global.xml
@@ -409,6 +409,22 @@
 				homogeneous. For each loaded interface the supported tables must
 				be provided.
 				</description>
+				<group name="default">
+					<description>
+					Configure the default travel-time table interface and model to be
+					used by all modules that supports configurable ttt.
+					</description>
+					<parameter name="tableType" type="string" default="LOCSAT">
+						<description>
+						The default travel-time tables type (interface) to use.
+						</description>
+					</parameter>
+					<parameter name="table" type="string" default="iasp91">
+						<description>
+						The default table (model) to use.
+						</description>
+					</parameter>
+				</group>
 				<struct type="ttt profile">
 					<parameter name="tables" type="list:string">
 						<description>

--- a/libs/seiscomp/gui/datamodel/amplitudeview.cpp
+++ b/libs/seiscomp/gui/datamodel/amplitudeview.cpp
@@ -1874,26 +1874,27 @@ void AmplitudeView::figureOutTravelTimeTable() {
 	}
 
 	if ( idx < 0 ) {
-		std::string defaultLocator = "LOCSAT";
+		std::string defaultTableType = "LOCSAT";
 		try {
-			defaultLocator = SCApp->configGetString("olv.locator.interface");
+			defaultTableType = SCApp->configGetString("ttt.default.tableType");
 		}
-		catch ( ... ) {
-			try {
-				defaultLocator = SCApp->configGetString("olv.locator");
-			}
-			catch ( ... ) {}
-		}
+		catch ( ... ) { }
 
-		idx = SC_D.comboTTT->findText(defaultLocator.c_str());
+		idx = SC_D.comboTTT->findText(defaultTableType.c_str());
 		if ( idx < 0 ) {
 			idx = SC_D.comboTTT->findText("LOCSAT");
+		}
+		else {
+			try {
+				SC_D.ttTableName = SCApp->configGetString("ttt.default.table");
+			}
+			catch ( ... ) { }
 		}
 	}
 
 	if ( idx >= 0 ) {
 		SC_D.comboTTT->setCurrentIndex(idx);
-	} 
+	}
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/libs/seiscomp/gui/datamodel/pickerview.cpp
+++ b/libs/seiscomp/gui/datamodel/pickerview.cpp
@@ -5083,20 +5083,21 @@ void PickerView::figureOutTravelTimeTable() {
 	}
 
 	if ( idx < 0 ) {
-		std::string defaultLocator = "LOCSAT";
+		std::string defaultTableType = "LOCSAT";
 		try {
-			defaultLocator = SCApp->configGetString("olv.locator.interface");
+			defaultTableType = SCApp->configGetString("ttt.default.tableType");
 		}
-		catch ( ... ) {
-			try {
-				defaultLocator = SCApp->configGetString("olv.locator");
-			}
-			catch ( ... ) {}
-		}
+		catch ( ... ) { }
 
-		idx = SC_D.comboTTT->findText(defaultLocator.c_str());
+		idx = SC_D.comboTTT->findText(defaultTableType.c_str());
 		if ( idx < 0 ) {
 			idx = SC_D.comboTTT->findText("LOCSAT");
+		}
+		else {
+			try {
+				SC_D.ttTableName = SCApp->configGetString("ttt.default.table");
+			}
+			catch ( ... ) { }
 		}
 	}
 


### PR DESCRIPTION
This is the implementation of a default ttt for the picker and amplitude views discussed in the forum.

> the only question is how to name the individual attributes: `tableType` has been used in other places as type and interface. `table` has been seen as model as well. We need to find a good terminology. 

Given the ttt configuration description and parameters currently in SeisComP are the following:

```
  <group name="ttt">
      <description>
      Configure interfaces to travel-time tables (travel-time
      interfaces). Built-in interfaces are LOCSAT, libtau and
      homogeneous. For each loaded interface the supported tables must
      be provided.
      </description>
      <struct type="ttt profile">
	      <parameter name="tables" type="list:string">
		      <description>
		      The list of supported table (model) names per interface.
		      </description>
	      </parameter>
      </struct>
```

What I called `tableType` in my PR may be better called `interface`, since this is how they are called in the description of `ttt` group. On the other hand, what I called `table` in my PR is a good name for the parameter, since the list of available interface models within a `ttt profile` is  called `tables` .

