### PR TITLE
Fixes memory leak in case of exception.

### DIFF
--- a/libs/seiscomp/core/archive.inl
+++ b/libs/seiscomp/core/archive.inl
@@ -715,8 +715,17 @@ inline void Archive<ROOT_TYPE>::readPtr(ROOT_TYPE*, T*& object) {
 			throw ClassNotFound(T::ClassName());
 	}
 
-	if ( object )
-		read(*object);
+	if ( object ) {
+             	try {
+			read(*object);
+		}
+		catch (...) {
+			delete object;
+			object = nullptr;
+			throw;
+		}
+
+	}
 	else
 		_validObject = false;
 
@@ -735,11 +744,17 @@ template <typename ROOT_TYPE>
 template <typename T>
 inline void Archive<ROOT_TYPE>::readPtr(void*, T*& object) {
 	object = new T;
-	read(*object);
+	try {
+	   	read(*object);
+	} catch (...) {
+		delete object;
+		object = nullptr;
+        	throw;
+	} 
 	if ( !success() ) {
 		delete object;
 		object = nullptr;
-	}
+	} 
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 


### PR DESCRIPTION
readPTR allocates memory to decode content. If the object to be decoded is of the wrong type, an exception is thrown without the memory being freed. In case of a misconfigured module, this will lead to uncontrolled memory growth.

This fix addresses the issue by catching the exception, freeing the memory and throwing it again.