### PR TITLE
[scolv] make eventedit.scripts.column.* work

### DIFF
--- a/libs/seiscomp/gui/datamodel/eventedit.cpp
+++ b/libs/seiscomp/gui/datamodel/eventedit.cpp
@@ -2753,7 +2753,7 @@ void EventEdit::insertOriginRow(Origin *org) {
 		}
 
 		PublicObjectEvaluator::Instance().prepend(this, org->publicID().c_str(),
-		                                          org->typeInfo().className(), scripts);
+		                                          org->typeInfo(), scripts);
 	}
 
 	_originTree->insertTopLevelItem(0, item);


### PR DESCRIPTION
Currently the special values added by eventedit.scripts.column.* are never visualized on the event edit tab of scolv